### PR TITLE
docs: CDK Construct パターンを採用したハンズオン資料の更新

### DIFF
--- a/docs/hands-on/05-service-implementation-hotel-payment.md
+++ b/docs/hands-on/05-service-implementation-hotel-payment.md
@@ -11,6 +11,110 @@
 * **永続化ストア**: 冪等性トークンを管理するための永続化層が必要です。
     * 本ハンズオンでは、Step 02 で作成したテーブルを使用します（別途 `IDEMPOTENCY#<key>` のようなキー設計を行うか、専用テーブルを作成するコードを追加します）。
 
+## CDK Construct への定義追加
+
+Hands-on 04 で作成した `Functions` Construct に、Hotel/Payment サービスの Lambda 関数を追加します。
+
+### infra/constructs/functions.py (追加)
+```python
+from aws_cdk import (
+    aws_dynamodb as dynamodb,
+    aws_lambda as _lambda,
+)
+from constructs import Construct
+
+
+class Functions(Construct):
+    """Lambda 関数を管理する Construct"""
+
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        table: dynamodb.Table,
+        common_layer: _lambda.LayerVersion,
+    ) -> None:
+        super().__init__(scope, id)
+
+        # ========================================================================
+        # Flight Service Lambda (Hands-on 04 で作成済み)
+        # ========================================================================
+        self.flight_reserve = _lambda.Function(...)
+        self.flight_cancel = _lambda.Function(
+            self, "FlightCancelLambda",
+            runtime=_lambda.Runtime.PYTHON_3_12,
+            handler="services.flight.handlers.cancel.lambda_handler",
+            code=_lambda.Code.from_asset("."),
+            layers=[common_layer],
+            environment={
+                "TABLE_NAME": table.table_name,
+                "POWERTOOLS_SERVICE_NAME": "flight-service",
+            },
+        )
+
+        # ========================================================================
+        # Hotel Service Lambda (今回追加)
+        # ========================================================================
+        self.hotel_reserve = _lambda.Function(
+            self, "HotelReserveLambda",
+            runtime=_lambda.Runtime.PYTHON_3_12,
+            handler="services.hotel.handlers.reserve.lambda_handler",
+            code=_lambda.Code.from_asset("."),
+            layers=[common_layer],
+            environment={
+                "TABLE_NAME": table.table_name,
+                "POWERTOOLS_SERVICE_NAME": "hotel-service",
+            },
+        )
+
+        self.hotel_cancel = _lambda.Function(
+            self, "HotelCancelLambda",
+            runtime=_lambda.Runtime.PYTHON_3_12,
+            handler="services.hotel.handlers.cancel.lambda_handler",
+            code=_lambda.Code.from_asset("."),
+            layers=[common_layer],
+            environment={
+                "TABLE_NAME": table.table_name,
+                "POWERTOOLS_SERVICE_NAME": "hotel-service",
+            },
+        )
+
+        # ========================================================================
+        # Payment Service Lambda (今回追加)
+        # ========================================================================
+        self.payment_process = _lambda.Function(
+            self, "PaymentProcessLambda",
+            runtime=_lambda.Runtime.PYTHON_3_12,
+            handler="services.payment.handlers.process.lambda_handler",
+            code=_lambda.Code.from_asset("."),
+            layers=[common_layer],
+            environment={
+                "TABLE_NAME": table.table_name,
+                "POWERTOOLS_SERVICE_NAME": "payment-service",
+            },
+        )
+
+        self.payment_refund = _lambda.Function(
+            self, "PaymentRefundLambda",
+            runtime=_lambda.Runtime.PYTHON_3_12,
+            handler="services.payment.handlers.refund.lambda_handler",
+            code=_lambda.Code.from_asset("."),
+            layers=[common_layer],
+            environment={
+                "TABLE_NAME": table.table_name,
+                "POWERTOOLS_SERVICE_NAME": "payment-service",
+            },
+        )
+
+        # DynamoDB への権限付与
+        table.grant_write_data(self.flight_reserve)
+        table.grant_write_data(self.flight_cancel)
+        table.grant_write_data(self.hotel_reserve)
+        table.grant_write_data(self.hotel_cancel)
+        table.grant_write_data(self.payment_process)
+        table.grant_write_data(self.payment_refund)
+```
+
 ## ブランチとコミットメッセージ
 
 *   **ブランチ名**: `feature/hotel-payment-service`

--- a/docs/hands-on/06-step-functions-orchestration.md
+++ b/docs/hands-on/06-step-functions-orchestration.md
@@ -11,6 +11,121 @@ Start -> Reserve Flight -> Reserve Hotel -> Process Payment -> Succeed
     * 単純な `output_path="$.Payload"` ではなく、**`result_path`** の使用を推奨します（例: `result_path="$.results.flight"`）。
     * これにより、前のステップの入力データ（予約IDや顧客情報）を上書きせずに保持したまま、後続のステップや補償トランザクション（キャンセル処理）で参照可能になります。
 
+### ファイル構成
+```
+infra/
+├── constructs/
+│   ├── __init__.py
+│   ├── database.py      # Hands-on 02 で作成済み
+│   ├── layers.py        # Hands-on 03 で作成済み
+│   ├── functions.py     # Hands-on 04, 05 で作成済み
+│   └── orchestration.py # Step Functions Construct (今回追加)
+```
+
+### infra/constructs/orchestration.py
+```python
+from aws_cdk import (
+    aws_stepfunctions as sfn,
+    aws_stepfunctions_tasks as tasks,
+    aws_lambda as _lambda,
+)
+from constructs import Construct
+
+
+class Orchestration(Construct):
+    """Step Functions ステートマシンを管理する Construct"""
+
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        flight_reserve: _lambda.Function,
+        hotel_reserve: _lambda.Function,
+        payment_process: _lambda.Function,
+    ) -> None:
+        super().__init__(scope, id)
+
+        # ========================================================================
+        # Task Definitions
+        # ========================================================================
+        reserve_flight_task = tasks.LambdaInvoke(
+            self, "ReserveFlight",
+            lambda_function=flight_reserve,
+            result_path="$.results.flight",
+        )
+
+        reserve_hotel_task = tasks.LambdaInvoke(
+            self, "ReserveHotel",
+            lambda_function=hotel_reserve,
+            result_path="$.results.hotel",
+        )
+
+        process_payment_task = tasks.LambdaInvoke(
+            self, "ProcessPayment",
+            lambda_function=payment_process,
+            result_path="$.results.payment",
+        )
+
+        # ========================================================================
+        # State Machine Definition (正常系フロー)
+        # ========================================================================
+        definition = (
+            reserve_flight_task
+            .next(reserve_hotel_task)
+            .next(process_payment_task)
+            .next(sfn.Succeed(self, "BookingSucceeded"))
+        )
+
+        self.state_machine = sfn.StateMachine(
+            self, "TripBookingStateMachine",
+            definition=definition,
+        )
+```
+
+### infra/constructs/\_\_init\_\_.py (更新)
+```python
+from .database import Database
+from .layers import Layers
+from .functions import Functions
+from .orchestration import Orchestration
+
+__all__ = ["Database", "Layers", "Functions", "Orchestration"]
+```
+
+### serverless_trip_saga_stack.py (更新)
+```python
+from aws_cdk import Stack
+from constructs import Construct
+from infra.constructs import Database, Layers, Functions, Orchestration
+
+
+class ServerlessTripSagaStack(Stack):
+
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Database Construct
+        database = Database(self, "Database")
+
+        # Layers Construct
+        layers = Layers(self, "Layers")
+
+        # Functions Construct
+        functions = Functions(
+            self, "Functions",
+            table=database.table,
+            common_layer=layers.common_layer,
+        )
+
+        # Orchestration Construct
+        orchestration = Orchestration(
+            self, "Orchestration",
+            flight_reserve=functions.flight_reserve,
+            hotel_reserve=functions.hotel_reserve,
+            payment_process=functions.payment_process,
+        )
+```
+
 ## ブランチとコミットメッセージ
 
 *   **ブランチ名**: `feature/step-functions`

--- a/docs/hands-on/11-observability-datadog.md
+++ b/docs/hands-on/11-observability-datadog.md
@@ -5,16 +5,136 @@
 ## 監視ツールの選択
 本ハンズオンでは高度な監視機能を持つ **Datadog** の導入手順を解説しますが、AWS標準機能のみで完結させたい場合は **CloudWatch ServiceLens (X-Ray)** を使用することも可能です。
 
+## CDK Construct への実装
+
+可観測性の設定を管理する Construct を作成します。
+
+### ファイル構成
+```
+infra/
+├── constructs/
+│   ├── __init__.py
+│   ├── database.py
+│   ├── layers.py
+│   ├── functions.py
+│   ├── orchestration.py
+│   ├── api.py
+│   ├── deployment.py
+│   └── observability.py  # 可観測性 Construct (今回追加)
+```
+
 ## パターンA: Datadog 実装 (Advanced)
 * **前提**: Datadog アカウントと API Key が必要です。
 * `datadog-cdk-constructs-v2` を使用。
 * Lambda Extension の導入、Trace/Log の連携。
 * Step Functions の可視化。
 
+### infra/constructs/observability.py (Datadog版)
+```python
+from datadog_cdk_constructs_v2 import Datadog
+from aws_cdk import aws_lambda as _lambda
+from constructs import Construct
+
+
+class Observability(Construct):
+    """可観測性を管理する Construct (Datadog版)"""
+
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        functions: list[_lambda.Function],
+        datadog_api_key_secret_arn: str,
+    ) -> None:
+        super().__init__(scope, id)
+
+        datadog = Datadog(
+            self, "Datadog",
+            python_layer_version=<LATEST_VERSION>,
+            extension_layer_version=<LATEST_VERSION>,
+            api_key_secret_arn=datadog_api_key_secret_arn,
+            enable_datadog_tracing=True,
+            enable_datadog_logs=True,
+        )
+
+        for fn in functions:
+            datadog.add_lambda_functions([fn])
+```
+
 ## パターンB: AWS Native 実装 (Standard)
 * **概要**: 追加アカウント不要で実装可能です。
 * CDKで `tracing=Tracing.ACTIVE` を Lambda および Step Functions State Machine に設定。
 * CloudWatch ServiceLens コンソールでサービスマップとトレースを確認。
+
+### infra/constructs/observability.py (AWS Native版)
+```python
+from aws_cdk import (
+    aws_lambda as _lambda,
+    aws_stepfunctions as sfn,
+)
+from constructs import Construct
+
+
+class Observability(Construct):
+    """可観測性を管理する Construct (AWS Native版)"""
+
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        functions: list[_lambda.Function],
+        state_machine: sfn.StateMachine,
+    ) -> None:
+        super().__init__(scope, id)
+
+        # Lambda 関数に X-Ray トレーシングを有効化
+        for fn in functions:
+            fn.add_environment("AWS_XRAY_TRACING_NAME", fn.function_name)
+```
+
+**注意**: AWS Native版の場合、Lambda関数とStep Functions作成時に `tracing` パラメータを設定する必要があります。
+
+### Functions Construct の更新 (AWS Native版)
+```python
+# infra/constructs/functions.py
+
+        self.flight_reserve = _lambda.Function(
+            self, "FlightReserveLambda",
+            runtime=_lambda.Runtime.PYTHON_3_12,
+            handler="services.flight.handlers.reserve.lambda_handler",
+            code=_lambda.Code.from_asset("."),
+            layers=[common_layer],
+            tracing=_lambda.Tracing.ACTIVE,  # X-Ray 有効化
+            environment={...},
+        )
+```
+
+### Orchestration Construct の更新 (AWS Native版)
+```python
+# infra/constructs/orchestration.py
+
+        self.state_machine = sfn.StateMachine(
+            self, "TripBookingStateMachine",
+            definition=definition,
+            tracing_enabled=True,  # X-Ray 有効化
+        )
+```
+
+### infra/constructs/\_\_init\_\_.py (更新)
+```python
+from .database import Database
+from .layers import Layers
+from .functions import Functions
+from .orchestration import Orchestration
+from .api import Api
+from .deployment import Deployment
+from .observability import Observability
+
+__all__ = [
+    "Database", "Layers", "Functions", "Orchestration",
+    "Api", "Deployment", "Observability"
+]
+```
 
 ## ブランチとコミットメッセージ
 


### PR DESCRIPTION
ハンズオン02〜11のCDK実装をConstruct分割パターンに統一。
- database.py: DynamoDB テーブル + GSI
- layers.py: Lambda Layers
- functions.py: 全Lambda関数
- orchestration.py: Step Functions
- api.py: API Gateway
- deployment.py: カナリアデプロイ
- observability.py: トレーシング設定