### PR TITLE
docs: テストコードの変数名を明示的な名前に改善

### DIFF
--- a/docs/hands-on/04-service-implementation-flight.md
+++ b/docs/hands-on/04-service-implementation-flight.md
@@ -1083,15 +1083,15 @@ class TestFlightNumber:
 
     def test_valid_flight_number(self):
         """正常なフライト番号を生成できる"""
-        fn = FlightNumber("NH001")
-        assert fn.value == "NH001"
-        assert fn.airline_code == "NH"
-        assert fn.flight_num == "001"
+        flight_number = FlightNumber("NH001")
+        assert flight_number.value == "NH001"
+        assert flight_number.airline_code == "NH"
+        assert flight_number.flight_num == "001"
 
     def test_lowercase_is_normalized(self):
         """小文字は大文字に正規化される"""
-        fn = FlightNumber("nh001")
-        assert fn.value == "NH001"
+        flight_number = FlightNumber("nh001")
+        assert flight_number.value == "NH001"
 
     def test_invalid_format_raises_error(self):
         """不正な形式はエラーになる"""
@@ -1100,9 +1100,9 @@ class TestFlightNumber:
 
     def test_equality(self):
         """同じ値なら等価"""
-        fn1 = FlightNumber("NH001")
-        fn2 = FlightNumber("NH001")
-        assert fn1 == fn2
+        flight_number_1 = FlightNumber("NH001")
+        flight_number_2 = FlightNumber("NH001")
+        assert flight_number_1 == flight_number_2
 ```
 
 ### 4.3 Entity のテスト（`test_booking.py`）


### PR DESCRIPTION
- fn → flight_number
- fn1, fn2 → flight_number_1, flight_number_2

可読性向上のため、省略された変数名を明示的な名前に変更