### PR TITLE
docs: Value Object等価性テストを削除

### DIFF
--- a/docs/hands-on/04-service-implementation-flight.md
+++ b/docs/hands-on/04-service-implementation-flight.md
@@ -1097,12 +1097,6 @@ class TestFlightNumber:
         """不正な形式はエラーになる"""
         with pytest.raises(ValueError):
             FlightNumber("INVALID")
-
-    def test_equality(self):
-        """同じ値なら等価"""
-        flight_number_1 = FlightNumber("NH001")
-        flight_number_2 = FlightNumber("NH001")
-        assert flight_number_1 == flight_number_2
 ```
 
 ### 4.3 Entity のテスト（`test_booking.py`）


### PR DESCRIPTION
現場で一般的に書かれないテストのため、ハンズオンドキュメントから削除。