### PR TITLE
fix: Factories as fixturesをconftest.pyではなくテストファイル内に定義

### DIFF
--- a/docs/hands-on/04-service-implementation-flight.md
+++ b/docs/hands-on/04-service-implementation-flight.md
@@ -1044,7 +1044,6 @@ Repository パターンを採用したことで、**DynamoDB への依存なし�
 ### 4.1 テストファイルの配置
 
 Value Object と Entity を分離したことで、テストも細かく分割できます。
-`conftest.py` には pytest の「Factories as fixtures」パターンを使用したテストデータ生成用の fixture を配置します。
 
 ```
 tests/unit/services/
@@ -1058,7 +1057,6 @@ tests/unit/services/
 │           └── test_iso_date_time.py
 └── flight/
     ├── __init__.py
-    ├── conftest.py           # Factories as fixtures（テストデータ生成）
     ├── domain/
     │   ├── entity/
     │   │   ├── __init__.py
@@ -1101,20 +1099,19 @@ class TestFlightNumber:
             FlightNumber("INVALID")
 ```
 
-### 4.3 Factories as fixtures（`conftest.py`）
+### 4.3 Entity のテスト（`test_booking.py`）
 
 pytest の「Factories as fixtures」パターンを使用して、テストデータ生成用の fixture を定義します。
 fixture から**関数（Factory）を返す**ことで、テストごとにパラメータを柔軟に変更できます。
 
 参考: https://docs.pytest.org/en/stable/how-to/fixtures.html#factories-as-fixtures
 
-`tests/unit/services/flight/conftest.py`
-
 ```python
 import pytest
 from decimal import Decimal
 
 from services.shared.domain import TripId, Money, Currency, IsoDateTime
+from services.shared.domain.exception import BusinessRuleViolationException
 
 from services.flight.domain.entity import Booking
 from services.flight.domain.enum import BookingStatus
@@ -1148,22 +1145,6 @@ def create_booking():
             status=status,
         )
     return _factory
-```
-
-### 4.4 Entity のテスト（`test_booking.py`）
-
-`conftest.py` で定義した `create_booking` fixture を使用してテストを記述します。
-
-```python
-import pytest
-from decimal import Decimal
-
-from services.shared.domain import TripId, Money, Currency, IsoDateTime
-from services.shared.domain.exception import BusinessRuleViolationException
-
-from services.flight.domain.entity import Booking
-from services.flight.domain.enum import BookingStatus
-from services.flight.domain.value_object import BookingId, FlightNumber
 
 
 class TestBooking:
@@ -1194,7 +1175,7 @@ class TestBooking:
             )
 ```
 
-### 4.5 Application Service のテスト（`test_reserve_flight.py`）
+### 4.4 Application Service のテスト（`test_reserve_flight.py`）
 
 ```python
 from decimal import Decimal

--- a/docs/hands-on/05-service-implementation-hotel-payment.md
+++ b/docs/hands-on/05-service-implementation-hotel-payment.md
@@ -1137,7 +1137,6 @@ class Functions(Construct):
 ### テストファイル構造
 
 Value Object と Entity を分離したことで、テストも細かく分割できます。
-各サービスディレクトリには `conftest.py` を配置し、**Factories as fixtures** パターンでテストデータ生成を共通化します。
 
 ```
 tests/unit/services/
@@ -1151,7 +1150,6 @@ tests/unit/services/
 │           └── test_iso_date_time.py
 ├── hotel/
 │   ├── __init__.py
-│   ├── conftest.py                    # Factories as fixtures（HotelBooking 生成用）
 │   ├── domain/
 │   │   ├── entity/
 │   │   │   ├── __init__.py
@@ -1165,7 +1163,6 @@ tests/unit/services/
 │   └── test_reserve_hotel.py
 └── payment/
     ├── __init__.py
-    ├── conftest.py                    # Factories as fixtures（Payment 生成用）
     ├── domain/
     │   ├── entity/
     │   │   ├── __init__.py
@@ -1176,8 +1173,6 @@ tests/unit/services/
     ├── test_payment_factory.py
     └── test_process_payment.py
 ```
-
-> **Note:** `conftest.py` の詳細な実装パターンについては [Hands-on 04: Service Implementation - Flight](./04-service-implementation-flight.md) の「テスト共通 fixture（conftest.py）」を参照してください。
 
 ## 8. パターンの効果
 


### PR DESCRIPTION
- 04-service-implementation-flight.md:
  - conftest.pyをファイル構成から削除
  - create_booking fixtureをtest_booking.py内に直接定義
  - セクション番号を調整（4.3→Entity, 4.4→Application）

- 05-service-implementation-hotel-payment.md:
  - conftest.pyをファイル構成から削除

このfixtureは test_booking.py でのみ使用されるため、
conftest.py に分離する必要がない。