### PR TITLE
refactor: 共通フィクスチャをconftest.pyに集約しテスト間の重複を排除

### DIFF
--- a/docs/hands-on/04-service-implementation-flight.md
+++ b/docs/hands-on/04-service-implementation-flight.md
@@ -1044,9 +1044,11 @@ Repository パターンを採用したことで、**DynamoDB への依存なし�
 ### 4.1 テストファイルの配置
 
 Value Object と Entity を分離したことで、テストも細かく分割できます。
+共通フィクスチャは `conftest.py` に配置し、テストコード間の重複を排除します。
 
 ```
 tests/unit/services/
+├── conftest.py                    ← 全サービス共通フィクスチャ（trip_id, mock_repository）
 ├── shared/
 │   └── domain/
 │       └── value_object/
@@ -1056,6 +1058,7 @@ tests/unit/services/
 │           ├── test_currency.py
 │           └── test_iso_date_time.py
 └── flight/
+    ├── conftest.py                ← Flight 固有フィクスチャ（create_booking）
     ├── __init__.py
     ├── domain/
     │   ├── entity/
@@ -1070,7 +1073,79 @@ tests/unit/services/
     └── test_reserve_flight.py
 ```
 
-### 4.2 Value Object のテスト（`test_flight_number.py`）
+### 4.2 共通フィクスチャの定義（`conftest.py`）
+
+pytest の `conftest.py` は、同一ディレクトリおよびサブディレクトリのテストから自動的に参照されるフィクスチャ定義ファイルです。
+テストガイドライン（`docs/02_testing_guidelines.md`）の「共通 fixture は `conftest.py` に配置」に従い、フィクスチャを一元管理します。
+
+#### 全サービス共通フィクスチャ（`tests/unit/services/conftest.py`）
+
+```python
+import pytest
+from unittest.mock import MagicMock
+
+from services.shared.domain.value_object.trip_id import TripId
+
+
+@pytest.fixture
+def trip_id():
+    """全テスト共通の TripId フィクスチャ"""
+    return TripId(value="trip-123")
+
+
+@pytest.fixture
+def mock_repository():
+    """リポジトリのモックフィクスチャ"""
+    return MagicMock()
+```
+
+- `trip_id`: 全サービスのテストで共通して使用する TripId
+- `mock_repository`: Application Service テストで使用する Repository のモック
+
+#### Flight 固有フィクスチャ（`tests/unit/services/flight/conftest.py`）
+
+```python
+import pytest
+from decimal import Decimal
+
+from services.flight.domain.entity import Booking
+from services.flight.domain.enum import BookingStatus
+from services.flight.domain.value_object import BookingId, FlightNumber
+from services.shared.domain import Currency, IsoDateTime, Money, TripId
+
+
+@pytest.fixture
+def create_booking():
+    """Booking を生成する Factory fixture（Factories as fixtures パターン）"""
+
+    def _factory(
+        status: BookingStatus = BookingStatus.PENDING,
+        booking_id: str = "test-id",
+        trip_id: str = "trip-123",
+        flight_number: str = "NH001",
+        departure_time: str = "2024-01-01T10:00:00",
+        arrival_time: str = "2024-01-01T12:00:00",
+        price_amount: Decimal = Decimal("50000"),
+    ) -> Booking:
+        return Booking(
+            id=BookingId(value=booking_id),
+            trip_id=TripId(value=trip_id),
+            flight_number=FlightNumber(value=flight_number),
+            departure_time=IsoDateTime.from_string(departure_time),
+            arrival_time=IsoDateTime.from_string(arrival_time),
+            price=Money(amount=price_amount, currency=Currency.jpy()),
+            status=status,
+        )
+
+    return _factory
+```
+
+「Factories as fixtures」パターンにより、オブジェクトそのものではなく「オブジェクトを作る関数」を返します。
+テストごとにパラメータを柔軟に変更できるため、Entity テストで特に有効です。
+
+参考: https://docs.pytest.org/en/stable/how-to/fixtures.html#factories-as-fixtures
+
+### 4.3 Value Object のテスト（`test_flight_number.py`）
 
 ```python
 import pytest
@@ -1099,111 +1174,80 @@ class TestFlightNumber:
             FlightNumber("INVALID")
 ```
 
-### 4.3 Entity のテスト（`test_booking.py`）
+### 4.4 Entity のテスト（`test_booking.py`）
 
-pytest の「Factories as fixtures」パターンを使用して、テストデータ生成用の fixture を定義します。
-fixture から**関数（Factory）を返す**ことで、テストごとにパラメータを柔軟に変更できます。
-
-参考: https://docs.pytest.org/en/stable/how-to/fixtures.html#factories-as-fixtures
+`conftest.py` に定義した `create_booking` フィクスチャを使用します。
+テストメソッドの引数に `create_booking` を指定するだけで、pytest が自動的に conftest.py から注入します。
 
 ```python
-import pytest
 from decimal import Decimal
 
-from services.shared.domain import TripId, Money, Currency, IsoDateTime
-from services.shared.domain.exception import BusinessRuleViolationException
+import pytest
 
 from services.flight.domain.entity import Booking
 from services.flight.domain.enum import BookingStatus
 from services.flight.domain.value_object import BookingId, FlightNumber
-
-
-@pytest.fixture
-def create_booking():
-    """Booking を生成する Factory を返す fixture
-
-    Factories as fixtures パターン:
-    オブジェクトそのものではなく「オブジェクトを作る関数」を返すことで、
-    テストごとにパラメータを柔軟に変更できる。
-    """
-    def _factory(
-        status: BookingStatus = BookingStatus.PENDING,
-        booking_id: str = "test-id",
-        trip_id: str = "trip-123",
-        flight_number: str = "NH001",
-        departure_time: str = "2024-01-01T10:00:00",
-        arrival_time: str = "2024-01-01T12:00:00",
-        price_amount: Decimal = Decimal("50000"),
-    ) -> Booking:
-        return Booking(
-            id=BookingId(value=booking_id),
-            trip_id=TripId(value=trip_id),
-            flight_number=FlightNumber(value=flight_number),
-            departure_time=IsoDateTime.from_string(departure_time),
-            arrival_time=IsoDateTime.from_string(arrival_time),
-            price=Money(amount=price_amount, currency=Currency.jpy()),
-            status=status,
-        )
-    return _factory
+from services.shared.domain import Currency, IsoDateTime, Money, TripId
+from services.shared.domain.exception.exceptions import BusinessRuleViolationException
 
 
 class TestBooking:
     """Booking Entity のテスト"""
 
     def test_confirm_pending_booking(self, create_booking):
-        """PENDING 状態の予約を確定できる"""
+        """PENDING状態の予約をconfirmするとCONFIRMED状態になる"""
         booking = create_booking(status=BookingStatus.PENDING)
         booking.confirm()
         assert booking.status == BookingStatus.CONFIRMED
 
     def test_cannot_confirm_cancelled_booking(self, create_booking):
-        """CANCELLED 状態の予約は確定できない"""
+        """CANCELLED状態の予約はconfirmできない"""
         booking = create_booking(status=BookingStatus.CANCELLED)
         with pytest.raises(BusinessRuleViolationException):
             booking.confirm()
 
     def test_invalid_schedule_raises_error(self):
-        """出発時刻が到着時刻より後の場合はエラー"""
+        """出発時刻よりも到着時刻が前の場合、例外が発生する"""
+        departure_time = IsoDateTime.from_string("2024-01-01T12:00:00")
+        arrival_time = IsoDateTime.from_string("2024-01-01T10:00:00")
+
         with pytest.raises(BusinessRuleViolationException):
             Booking(
                 id=BookingId(value="test-id"),
                 trip_id=TripId(value="trip-123"),
                 flight_number=FlightNumber(value="NH001"),
-                departure_time=IsoDateTime.from_string("2024-01-01T12:00:00"),  # 後
-                arrival_time=IsoDateTime.from_string("2024-01-01T10:00:00"),    # 前
+                departure_time=departure_time,
+                arrival_time=arrival_time,
                 price=Money(amount=Decimal("50000"), currency=Currency.jpy()),
             )
 ```
 
-### 4.4 Application Service のテスト（`test_reserve_flight.py`）
+### 4.5 Application Service のテスト（`test_reserve_flight.py`）
+
+`conftest.py` の `mock_repository` と `trip_id` フィクスチャを使用します。
+テストメソッドの引数に指定するだけで、pytest が自動的に注入します。
 
 ```python
 from decimal import Decimal
-from unittest.mock import MagicMock
-
-from services.shared.domain import TripId
 
 from services.flight.applications.reserve_flight import ReserveFlightService
-from services.flight.domain.entity import Booking
-from services.flight.domain.enum import BookingStatus
+from services.flight.domain.entity.booking import Booking
+from services.flight.domain.enum.booking_status import BookingStatus
 from services.flight.domain.factory import BookingFactory
+from services.flight.domain.factory.booking_factory import FlightDetails
 
 
 class TestReserveFlightService:
     """ReserveFlightService のテスト"""
 
-    def test_reserve_creates_and_saves_booking(self):
+    def test_reserve_create_and_saves_booking(self, mock_repository, trip_id):
         """予約が作成され、Repository に保存され、Entity が返される"""
-        # Arrange
-        mock_repository = MagicMock()
-        factory = BookingFactory()
-        service = ReserveFlightService(
-            repository=mock_repository,
-            factory=factory,
-        )
 
-        trip_id = TripId(value="trip-123")
-        flight_details = {
+        # Arrange
+        factory = BookingFactory()
+        service = ReserveFlightService(repository=mock_repository, factory=factory)
+
+        flight_details: FlightDetails = {
             "flight_number": "NH001",
             "departure_time": "2024-01-01T10:00:00",
             "arrival_time": "2024-01-01T12:00:00",
@@ -1214,12 +1258,11 @@ class TestReserveFlightService:
         # Act
         booking = service.reserve(trip_id, flight_details)
 
-        # Assert: Entity が返されること
+        # Assert
         assert isinstance(booking, Booking)
         assert booking.trip_id == trip_id
         assert booking.status == BookingStatus.PENDING
 
-        # Assert: Repository.save が呼ばれたこと
         mock_repository.save.assert_called_once()
         saved_booking = mock_repository.save.call_args[0][0]
         assert saved_booking == booking

--- a/docs/hands-on/05-service-implementation-hotel-payment.md
+++ b/docs/hands-on/05-service-implementation-hotel-payment.md
@@ -1137,9 +1137,11 @@ class Functions(Construct):
 ### テストファイル構造
 
 Value Object と Entity を分離したことで、テストも細かく分割できます。
+Hands-on 04 で作成した共通フィクスチャ（`conftest.py`）に加え、Hotel/Payment 固有のフィクスチャも `conftest.py` に配置します。
 
 ```
 tests/unit/services/
+├── conftest.py                    ← Hands-on 04 で作成済み（trip_id, mock_repository）
 ├── shared/
 │   └── domain/
 │       └── value_object/
@@ -1149,6 +1151,7 @@ tests/unit/services/
 │           ├── test_currency.py
 │           └── test_iso_date_time.py
 ├── hotel/
+│   ├── conftest.py                ← Hotel 固有フィクスチャ（create_hotel_booking）
 │   ├── __init__.py
 │   ├── domain/
 │   │   ├── entity/
@@ -1162,6 +1165,7 @@ tests/unit/services/
 │   ├── test_hotel_booking_factory.py
 │   └── test_reserve_hotel.py
 └── payment/
+    ├── conftest.py                ← Payment 固有フィクスチャ（create_payment）
     ├── __init__.py
     ├── domain/
     │   ├── entity/

--- a/tests/unit/services/conftest.py
+++ b/tests/unit/services/conftest.py
@@ -1,0 +1,17 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.shared.domain.value_object.trip_id import TripId
+
+
+@pytest.fixture
+def trip_id():
+    """全テスト共通の TripId フィクスチャ"""
+    return TripId(value="trip-123")
+
+
+@pytest.fixture
+def mock_repository():
+    """リポジトリのモックフィクスチャ"""
+    return MagicMock()

--- a/tests/unit/services/flight/conftest.py
+++ b/tests/unit/services/flight/conftest.py
@@ -1,0 +1,34 @@
+from decimal import Decimal
+
+import pytest
+
+from services.flight.domain.entity import Booking
+from services.flight.domain.enum import BookingStatus
+from services.flight.domain.value_object import BookingId, FlightNumber
+from services.shared.domain import Currency, IsoDateTime, Money, TripId
+
+
+@pytest.fixture
+def create_booking():
+    """Booking を生成する Factory fixture（Factories as fixtures パターン）"""
+
+    def _factory(
+        status: BookingStatus = BookingStatus.PENDING,
+        booking_id: str = "test-id",
+        trip_id: str = "trip-123",
+        flight_number: str = "NH001",
+        departure_time: str = "2024-01-01T10:00:00",
+        arrival_time: str = "2024-01-01T12:00:00",
+        price_amount: Decimal = Decimal("50000"),
+    ) -> Booking:
+        return Booking(
+            id=BookingId(value=booking_id),
+            trip_id=TripId(value=trip_id),
+            flight_number=FlightNumber(value=flight_number),
+            departure_time=IsoDateTime.from_string(departure_time),
+            arrival_time=IsoDateTime.from_string(arrival_time),
+            price=Money(amount=price_amount, currency=Currency.jpy()),
+            status=status,
+        )
+
+    return _factory

--- a/tests/unit/services/flight/domain/entity/test_booking.py
+++ b/tests/unit/services/flight/domain/entity/test_booking.py
@@ -12,31 +12,6 @@ from services.shared.domain.exception.exceptions import BusinessRuleViolationExc
 class TestBooking:
     """Booking Entity のテスト"""
 
-    @pytest.fixture
-    def create_booking(self):
-        """Bookingを生成するFactoryを返す"""
-
-        def _factory(
-            status: BookingStatus = BookingStatus.PENDING,
-            booking_id: str = "test-id",
-            trip_id: str = "trip-123",
-            flight_number: str = "NH001",
-            departure_time: str = "2024-01-01T10:00:00",
-            arrival_time: str = "2024-01-01T12:00:00",
-            price_amount: Decimal = Decimal("50000"),
-        ) -> Booking:
-            return Booking(
-                id=BookingId(value=booking_id),
-                trip_id=TripId(value=trip_id),
-                flight_number=FlightNumber(value=flight_number),
-                departure_time=IsoDateTime.from_string(departure_time),
-                arrival_time=IsoDateTime.from_string(arrival_time),
-                price=Money(amount=price_amount, currency=Currency.jpy()),
-                status=status,
-            )
-
-        return _factory
-
     def test_confirm_pending_booking(self, create_booking):
         """PENDING状態の予約をconfirmするとCONFIRMED状態になる"""
         booking = create_booking(status=BookingStatus.PENDING)

--- a/tests/unit/services/flight/test_reserve_flight.py
+++ b/tests/unit/services/flight/test_reserve_flight.py
@@ -1,26 +1,22 @@
 from decimal import Decimal
-from unittest.mock import MagicMock
 
 from services.flight.applications.reserve_flight import ReserveFlightService
 from services.flight.domain.entity.booking import Booking
 from services.flight.domain.enum.booking_status import BookingStatus
 from services.flight.domain.factory import BookingFactory
 from services.flight.domain.factory.booking_factory import FlightDetails
-from services.shared.domain.value_object.trip_id import TripId
 
 
 class TestReserveFlightService:
     """ReserveFlightService のテスト"""
 
-    def test_reserve_create_and_saves_booking(self):
+    def test_reserve_create_and_saves_booking(self, mock_repository, trip_id):
         """予約が作成され、Repository に保存され、Entity が返される"""
 
         # Arrange
-        mock_repository = MagicMock()
         factory = BookingFactory()
         service = ReserveFlightService(repository=mock_repository, factory=factory)
 
-        trip_id = TripId(value="trip-123")
         flight_details: FlightDetails = {
             "flight_number": "NH001",
             "departure_time": "2024-01-01T10:00:00",

--- a/tests/unit/services/hotel/conftest.py
+++ b/tests/unit/services/hotel/conftest.py
@@ -1,0 +1,35 @@
+from decimal import Decimal
+
+import pytest
+
+from services.hotel.domain.entity.hotel_booking import HotelBooking
+from services.hotel.domain.enum.hotel_booking_status import HotelBookingStatus
+from services.hotel.domain.value_object.hotel_booking_id import HotelBookingId
+from services.hotel.domain.value_object.hotel_name import HotelName
+from services.hotel.domain.value_object.stay_period import StayPeriod
+from services.shared.domain import Currency, Money, TripId
+
+
+@pytest.fixture
+def create_hotel_booking():
+    """HotelBooking を生成する Factory fixture（Factories as fixtures パターン）"""
+
+    def _factory(
+        status: HotelBookingStatus = HotelBookingStatus.PENDING,
+        booking_id: str = "test-id",
+        trip_id: str = "trip-123",
+        hotel_name: str = "Grand Hotel",
+        check_in: str = "2024-01-01",
+        check_out: str = "2024-01-03",
+        price_amount: Decimal = Decimal("30000"),
+    ) -> HotelBooking:
+        return HotelBooking(
+            id=HotelBookingId(value=booking_id),
+            trip_id=TripId(value=trip_id),
+            hotel_name=HotelName(value=hotel_name),
+            stay_period=StayPeriod(check_in=check_in, check_out=check_out),
+            price=Money(amount=price_amount, currency=Currency.jpy()),
+            status=status,
+        )
+
+    return _factory

--- a/tests/unit/services/hotel/domain/entity/test_hotel_booking.py
+++ b/tests/unit/services/hotel/domain/entity/test_hotel_booking.py
@@ -1,66 +1,39 @@
-from decimal import Decimal
-
 import pytest
 
-from services.hotel.domain.entity.hotel_booking import HotelBooking
 from services.hotel.domain.enum.hotel_booking_status import HotelBookingStatus
-from services.hotel.domain.value_object.hotel_booking_id import HotelBookingId
 from services.hotel.domain.value_object.hotel_name import HotelName
-from services.hotel.domain.value_object.stay_period import StayPeriod
-from services.shared.domain import Currency, Money, TripId
+from services.shared.domain import TripId
 from services.shared.domain.exception.exceptions import BusinessRuleViolationException
 
 
 class TestHotelBooking:
-    @pytest.fixture
-    def create_booking(self):
-        def _factory(
-            status: HotelBookingStatus = HotelBookingStatus.PENDING,
-            booking_id: str = "test-id",
-            trip_id: str = "trip-123",
-            hotel_name: str = "Grand Hotel",
-            check_in: str = "2024-01-01",
-            check_out: str = "2024-01-03",
-            price_amount: Decimal = Decimal("30000"),
-        ) -> HotelBooking:
-            return HotelBooking(
-                id=HotelBookingId(value=booking_id),
-                trip_id=TripId(value=trip_id),
-                hotel_name=HotelName(value=hotel_name),
-                stay_period=StayPeriod(check_in=check_in, check_out=check_out),
-                price=Money(amount=price_amount, currency=Currency.jpy()),
-                status=status,
-            )
-
-        return _factory
-
-    def test_confirm_pending_booking(self, create_booking):
-        booking = create_booking(status=HotelBookingStatus.PENDING)
+    def test_confirm_pending_booking(self, create_hotel_booking):
+        booking = create_hotel_booking(status=HotelBookingStatus.PENDING)
         booking.confirm()
         assert booking.status == HotelBookingStatus.CONFIRMED
 
-    def test_cannot_confirm_cancelled_booking(self, create_booking):
-        booking = create_booking(status=HotelBookingStatus.CANCELED)
+    def test_cannot_confirm_cancelled_booking(self, create_hotel_booking):
+        booking = create_hotel_booking(status=HotelBookingStatus.CANCELED)
         with pytest.raises(BusinessRuleViolationException):
             booking.confirm()
 
-    def test_cancel_pending_booking(self, create_booking):
-        booking = create_booking(status=HotelBookingStatus.PENDING)
+    def test_cancel_pending_booking(self, create_hotel_booking):
+        booking = create_hotel_booking(status=HotelBookingStatus.PENDING)
         booking.cancel()
         assert booking.status == HotelBookingStatus.CANCELED
 
-    def test_cancel_confirmed_booking(self, create_booking):
-        booking = create_booking(status=HotelBookingStatus.CONFIRMED)
+    def test_cancel_confirmed_booking(self, create_hotel_booking):
+        booking = create_hotel_booking(status=HotelBookingStatus.CONFIRMED)
         booking.cancel()
         assert booking.status == HotelBookingStatus.CANCELED
 
-    def test_cancel_already_cancelled_booking(self, create_booking):
-        booking = create_booking(status=HotelBookingStatus.CANCELED)
+    def test_cancel_already_cancelled_booking(self, create_hotel_booking):
+        booking = create_hotel_booking(status=HotelBookingStatus.CANCELED)
         booking.cancel()
         assert booking.status == HotelBookingStatus.CANCELED
 
-    def test_booking_properties(self, create_booking):
-        booking = create_booking()
+    def test_booking_properties(self, create_hotel_booking):
+        booking = create_hotel_booking()
         assert booking.trip_id == TripId(value="trip-123")
         assert booking.hotel_name == HotelName(value="Grand Hotel")
         assert booking.status == HotelBookingStatus.PENDING

--- a/tests/unit/services/hotel/test_hotel_booking_factory.py
+++ b/tests/unit/services/hotel/test_hotel_booking_factory.py
@@ -6,13 +6,11 @@ from services.hotel.domain.factory.hotel_booking_factory import (
     HotelBookingFactory,
     HotelDetails,
 )
-from services.shared.domain import TripId
 
 
 class TestHotelBookingFactory:
-    def test_create_hotel_booking(self):
+    def test_create_hotel_booking(self, trip_id):
         factory = HotelBookingFactory()
-        trip_id = TripId(value="trip-123")
         hotel_details: HotelDetails = {
             "hotel_name": "Grand Hotel",
             "check_in_date": "2024-01-01",

--- a/tests/unit/services/hotel/test_reserve_hotel.py
+++ b/tests/unit/services/hotel/test_reserve_hotel.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from unittest.mock import MagicMock
 
 from services.hotel.applications.reserve_hotel import ReserveHotelService
 from services.hotel.domain.entity.hotel_booking import HotelBooking
@@ -8,15 +7,12 @@ from services.hotel.domain.factory.hotel_booking_factory import (
     HotelBookingFactory,
     HotelDetails,
 )
-from services.shared.domain import TripId
 
 
 class TestReserveHotelService:
-    def test_reserve_creates_and_saves_booking(self):
-        mock_repository = MagicMock()
+    def test_reserve_creates_and_saves_booking(self, mock_repository, trip_id):
         factory = HotelBookingFactory()
         service = ReserveHotelService(repository=mock_repository, factory=factory)
-        trip_id = TripId(value="trip-123")
         hotel_details: HotelDetails = {
             "hotel_name": "Grand Hotel",
             "check_in_date": "2024-01-01",

--- a/tests/unit/services/payment/conftest.py
+++ b/tests/unit/services/payment/conftest.py
@@ -1,0 +1,28 @@
+from decimal import Decimal
+
+import pytest
+
+from services.payment.domain.entity.payment import Payment
+from services.payment.domain.enum.payment_status import PaymentStatus
+from services.payment.domain.value_object.payment_id import PaymentId
+from services.shared.domain import Currency, Money, TripId
+
+
+@pytest.fixture
+def create_payment():
+    """Payment を生成する Factory fixture（Factories as fixtures パターン）"""
+
+    def _factory(
+        status: PaymentStatus = PaymentStatus.PENDING,
+        payment_id: str = "test-id",
+        trip_id: str = "trip-123",
+        amount: Decimal = Decimal("50000"),
+    ) -> Payment:
+        return Payment(
+            id=PaymentId(value=payment_id),
+            trip_id=TripId(value=trip_id),
+            amount=Money(amount=amount, currency=Currency.jpy()),
+            status=status,
+        )
+
+    return _factory

--- a/tests/unit/services/payment/domain/entity/test_payment.py
+++ b/tests/unit/services/payment/domain/entity/test_payment.py
@@ -2,31 +2,12 @@ from decimal import Decimal
 
 import pytest
 
-from services.payment.domain.entity.payment import Payment
 from services.payment.domain.enum.payment_status import PaymentStatus
-from services.payment.domain.value_object.payment_id import PaymentId
 from services.shared.domain import Currency, Money, TripId
 from services.shared.domain.exception.exceptions import BusinessRuleViolationException
 
 
 class TestPayment:
-    @pytest.fixture
-    def create_payment(self):
-        def _factory(
-            status: PaymentStatus = PaymentStatus.PENDING,
-            payment_id: str = "test-id",
-            trip_id: str = "trip-123",
-            amount: Decimal = Decimal("50000"),
-        ) -> Payment:
-            return Payment(
-                id=PaymentId(value=payment_id),
-                trip_id=TripId(value=trip_id),
-                amount=Money(amount=amount, currency=Currency.jpy()),
-                status=status,
-            )
-
-        return _factory
-
     def test_complete_pending_payment(self, create_payment):
         payment = create_payment(status=PaymentStatus.PENDING)
         payment.complete()

--- a/tests/unit/services/payment/test_payment_factory.py
+++ b/tests/unit/services/payment/test_payment_factory.py
@@ -3,13 +3,11 @@ from decimal import Decimal
 from services.payment.domain.entity.payment import Payment
 from services.payment.domain.enum.payment_status import PaymentStatus
 from services.payment.domain.factory.payment_factory import PaymentFactory
-from services.shared.domain import TripId
 
 
 class TestPaymentFactory:
-    def test_create_payment(self):
+    def test_create_payment(self, trip_id):
         factory = PaymentFactory()
-        trip_id = TripId(value="trip-123")
 
         payment = factory.create(
             trip_id=trip_id,

--- a/tests/unit/services/payment/test_process_payment.py
+++ b/tests/unit/services/payment/test_process_payment.py
@@ -1,19 +1,17 @@
 from decimal import Decimal
-from unittest.mock import MagicMock
 
 from services.payment.applications.process_payment import ProcessPaymentService
 from services.payment.domain.entity.payment import Payment
 from services.payment.domain.enum.payment_status import PaymentStatus
 from services.payment.domain.factory.payment_factory import PaymentFactory
-from services.shared.domain import TripId
 
 
 class TestProcessPaymentService:
-    def test_process_creates_completes_and_saves_payment(self):
-        mock_repository = MagicMock()
+    def test_process_creates_completes_and_saves_payment(
+        self, mock_repository, trip_id
+    ):
         factory = PaymentFactory()
         service = ProcessPaymentService(repository=mock_repository, factory=factory)
-        trip_id = TripId(value="trip-123")
 
         payment = service.process(
             trip_id=trip_id,


### PR DESCRIPTION
テストガイドラインの「共通fixtureはconftest.pyに配置」に従い、
各テストファイルに散在していたフィクスチャをconftest.pyに昇格。
ハンズオンドキュメント(04, 05)もconftest.pyパターンに更新。