### PR TITLE
fix: find_by_idのscanをget_itemに置換してO(1)検索に改善

### DIFF
--- a/services/flight/infrastructure/dynamodb_booking_repository.py
+++ b/services/flight/infrastructure/dynamodb_booking_repository.py
@@ -49,14 +49,17 @@ class DynamoDBBookingRepository(BookingRepository):
 
     def find_by_id(self, booking_id: BookingId) -> Optional[Booking]:
         """予約IDで検索"""
-        response = self.table.scan(
-            FilterExpression="booking_id = :bid",
-            ExpressionAttributeValues={":bid": str(booking_id)},
+        trip_id = str(booking_id).removeprefix("flight_for_#")
+        response = self.table.get_item(
+            Key={
+                "PK": f"TRIP#{trip_id}",
+                "SK": f"FLIGHT#{booking_id}",
+            }
         )
-        items = response.get("Items", [])
-        if not items:
+        item = response.get("Item")
+        if not item:
             return None
-        return self._to_entity(items[0])
+        return self._to_entity(item)
 
     def find_by_trip_id(self, trip_id: TripId) -> Optional[Booking]:
         """Trip ID でフライト予約を検索する"""

--- a/services/hotel/infrastructure/dynamodb_hotel_booking_repository.py
+++ b/services/hotel/infrastructure/dynamodb_hotel_booking_repository.py
@@ -48,14 +48,17 @@ class DynamoDBHotelBookingRepository(HotelBookingRepository):
 
     def find_by_id(self, booking_id: HotelBookingId) -> Optional[HotelBooking]:
         """予約IDで検索"""
-        response = self.table.scan(
-            FilterExpression="booking_id = :bid",
-            ExpressionAttributeValues={":bid": str(booking_id)},
+        trip_id = str(booking_id).removeprefix("hotel_for_")
+        response = self.table.get_item(
+            Key={
+                "PK": f"TRIP#{trip_id}",
+                "SK": f"HOTEL#{booking_id}",
+            }
         )
-        items = response.get("Items", [])
-        if not items:
+        item = response.get("Item")
+        if not item:
             return None
-        return self._to_entity(items[0])
+        return self._to_entity(item)
 
     def find_by_trip_id(self, trip_id: TripId) -> Optional[HotelBooking]:
         """Trip ID でホテル予約を検索する"""


### PR DESCRIPTION
booking_idからtrip_idを逆算可能な命名規則を活用し、
PK+SKによるget_itemでの直接取得に変更。
hotel/flight両サービスに適用。