### PR TITLE
docs: ハンズオン設計書の__all__を冗長エイリアス方式(import X as X)に統一

### DIFF
--- a/docs/hands-on/02-dynamodb-design.md
+++ b/docs/hands-on/02-dynamodb-design.md
@@ -67,9 +67,7 @@ class Database(Construct):
 
 #### 2. infra/constructs/\_\_init\_\_.py
 ```python
-from .database import Database
-
-__all__ = ["Database"]
+from .database import Database as Database
 ```
 
 #### 3. serverless_trip_saga_stack.py

--- a/docs/hands-on/03-shared-kernel-and-layers.md
+++ b/docs/hands-on/03-shared-kernel-and-layers.md
@@ -73,10 +73,8 @@ class Layers(Construct):
 
 #### infra/constructs/\_\_init\_\_.py (更新)
 ```python
-from .database import Database
-from .layers import Layers
-
-__all__ = ["Database", "Layers"]
+from .database import Database as Database
+from .layers import Layers as Layers
 ```
 
 #### serverless_trip_saga_stack.py (更新)
@@ -269,23 +267,12 @@ services/shared/
 ### 5.5 `__init__.py` の更新 (`services/shared/domain/__init__.py`)
 
 ```python
-from .exceptions import (
-    DomainException,
-    ResourceNotFoundException,
-    BusinessRuleViolationException,
-)
-from .entity import Entity
-from .aggregate import AggregateRoot
-from .repository import Repository
-
-__all__ = [
-    "DomainException",
-    "ResourceNotFoundException",
-    "BusinessRuleViolationException",
-    "Entity",
-    "AggregateRoot",
-    "Repository",
-]
+from .aggregate import AggregateRoot as AggregateRoot
+from .entity import Entity as Entity
+from .exceptions import BusinessRuleViolationException as BusinessRuleViolationException
+from .exceptions import DomainException as DomainException
+from .exceptions import ResourceNotFoundException as ResourceNotFoundException
+from .repository import Repository as Repository
 ```
 
 ## 6. 次のステップ

--- a/docs/hands-on/04-service-implementation-flight.md
+++ b/docs/hands-on/04-service-implementation-flight.md
@@ -231,27 +231,16 @@ class IsoDateTime:
 #### shared/domain/__init__.py の更新
 
 ```python
-from .entity import Entity, AggregateRoot
-from .repository import Repository
-from .exception import (
-    DomainException,
-    ResourceNotFoundException,
-    BusinessRuleViolationException,
-)
-from .value_object import TripId, Currency, Money, IsoDateTime
-
-__all__ = [
-    "Entity",
-    "AggregateRoot",
-    "Repository",
-    "DomainException",
-    "ResourceNotFoundException",
-    "BusinessRuleViolationException",
-    "TripId",
-    "Currency",
-    "Money",
-    "IsoDateTime",
-]
+from .entity import AggregateRoot as AggregateRoot
+from .entity import Entity as Entity
+from .exception import BusinessRuleViolationException as BusinessRuleViolationException
+from .exception import DomainException as DomainException
+from .exception import ResourceNotFoundException as ResourceNotFoundException
+from .repository import Repository as Repository
+from .value_object import Currency as Currency
+from .value_object import IsoDateTime as IsoDateTime
+from .value_object import Money as Money
+from .value_object import TripId as TripId
 ```
 
 ### 3.2 Flight 固有の Value Object
@@ -431,21 +420,13 @@ class Booking(AggregateRoot[BookingId]):
 ### 3.4 Domain Layer: flight/domain/__init__.py
 
 ```python
-from .entity import Booking
-from .enum import BookingStatus
-from .factory import BookingFactory, FlightDetails
-from .repository import BookingRepository
-from .value_object import BookingId, FlightNumber
-
-__all__ = [
-    "Booking",
-    "BookingId",
-    "BookingStatus",
-    "FlightNumber",
-    "BookingRepository",
-    "BookingFactory",
-    "FlightDetails",
-]
+from .entity import Booking as Booking
+from .enum import BookingStatus as BookingStatus
+from .factory import BookingFactory as BookingFactory
+from .factory import FlightDetails as FlightDetails
+from .repository import BookingRepository as BookingRepository
+from .value_object import BookingId as BookingId
+from .value_object import FlightNumber as FlightNumber
 ```
 
 ### 3.5 Domain Layer: Repository インターフェース
@@ -1337,11 +1318,9 @@ class Functions(Construct):
 
 ### infra/constructs/\_\_init\_\_.py (更新)
 ```python
-from .database import Database
-from .layers import Layers
-from .functions import Functions
-
-__all__ = ["Database", "Layers", "Functions"]
+from .database import Database as Database
+from .functions import Functions as Functions
+from .layers import Layers as Layers
 ```
 
 ### serverless_trip_saga_stack.py (更新)

--- a/docs/hands-on/05-service-implementation-hotel-payment.md
+++ b/docs/hands-on/05-service-implementation-hotel-payment.md
@@ -262,22 +262,14 @@ class HotelBooking(AggregateRoot[HotelBookingId]):
 ### 4.4 Domain Layer: hotel/domain/__init__.py
 
 ```python
-from .entity import HotelBooking
-from .enum import HotelBookingStatus
-from .factory import HotelBookingFactory, HotelDetails
-from .repository import HotelBookingRepository
-from .value_object import HotelBookingId, HotelName, StayPeriod
-
-__all__ = [
-    "HotelBooking",
-    "HotelBookingId",
-    "HotelBookingStatus",
-    "HotelName",
-    "StayPeriod",
-    "HotelBookingRepository",
-    "HotelBookingFactory",
-    "HotelDetails",
-]
+from .entity import HotelBooking as HotelBooking
+from .enum import HotelBookingStatus as HotelBookingStatus
+from .factory import HotelBookingFactory as HotelBookingFactory
+from .factory import HotelDetails as HotelDetails
+from .repository import HotelBookingRepository as HotelBookingRepository
+from .value_object import HotelBookingId as HotelBookingId
+from .value_object import HotelName as HotelName
+from .value_object import StayPeriod as StayPeriod
 ```
 
 ### 4.5 Domain Layer: Factory
@@ -750,19 +742,11 @@ class Payment(AggregateRoot[PaymentId]):
 ### 5.4 Domain Layer: payment/domain/__init__.py
 
 ```python
-from .entity import Payment
-from .enum import PaymentStatus
-from .factory import PaymentFactory
-from .repository import PaymentRepository
-from .value_object import PaymentId
-
-__all__ = [
-    "Payment",
-    "PaymentId",
-    "PaymentStatus",
-    "PaymentRepository",
-    "PaymentFactory",
-]
+from .entity import Payment as Payment
+from .enum import PaymentStatus as PaymentStatus
+from .factory import PaymentFactory as PaymentFactory
+from .repository import PaymentRepository as PaymentRepository
+from .value_object import PaymentId as PaymentId
 ```
 
 ### 5.5 Domain Layer: Factory

--- a/docs/hands-on/06-step-functions-orchestration.md
+++ b/docs/hands-on/06-step-functions-orchestration.md
@@ -94,12 +94,10 @@ class Orchestration(Construct):
 
 ### infra/constructs/\_\_init\_\_.py (更新)
 ```python
-from .database import Database
-from .layers import Layers
-from .functions import Functions
-from .orchestration import Orchestration
-
-__all__ = ["Database", "Layers", "Functions", "Orchestration"]
+from .database import Database as Database
+from .functions import Functions as Functions
+from .layers import Layers as Layers
+from .orchestration import Orchestration as Orchestration
 ```
 
 ### serverless_trip_saga_stack.py (更新)

--- a/docs/hands-on/08-api-gateway-integration.md
+++ b/docs/hands-on/08-api-gateway-integration.md
@@ -210,13 +210,11 @@ class Api(Construct):
 
 ### 4.3 infra/constructs/\_\_init\_\_.py (更新)
 ```python
-from .database import Database
-from .layers import Layers
-from .functions import Functions
-from .orchestration import Orchestration
-from .api import Api
-
-__all__ = ["Database", "Layers", "Functions", "Orchestration", "Api"]
+from .api import Api as Api
+from .database import Database as Database
+from .functions import Functions as Functions
+from .layers import Layers as Layers
+from .orchestration import Orchestration as Orchestration
 ```
 
 ### 4.4 serverless_trip_saga_stack.py (更新)

--- a/docs/hands-on/10-canary-deployment.md
+++ b/docs/hands-on/10-canary-deployment.md
@@ -124,14 +124,12 @@ class Deployment(Construct):
 
 ### infra/constructs/\_\_init\_\_.py (更新)
 ```python
-from .database import Database
-from .layers import Layers
-from .functions import Functions
-from .orchestration import Orchestration
-from .api import Api
-from .deployment import Deployment
-
-__all__ = ["Database", "Layers", "Functions", "Orchestration", "Api", "Deployment"]
+from .api import Api as Api
+from .database import Database as Database
+from .deployment import Deployment as Deployment
+from .functions import Functions as Functions
+from .layers import Layers as Layers
+from .orchestration import Orchestration as Orchestration
 ```
 
 ### serverless_trip_saga_stack.py (更新)

--- a/docs/hands-on/11-observability-datadog.md
+++ b/docs/hands-on/11-observability-datadog.md
@@ -63,18 +63,13 @@ class Observability(Construct):
 
 ### infra/constructs/\_\_init\_\_.py (更新)
 ```python
-from .database import Database
-from .layers import Layers
-from .functions import Functions
-from .orchestration import Orchestration
-from .api import Api
-from .deployment import Deployment
-from .observability import Observability
-
-__all__ = [
-    "Database", "Layers", "Functions", "Orchestration",
-    "Api", "Deployment", "Observability"
-]
+from .api import Api as Api
+from .database import Database as Database
+from .deployment import Deployment as Deployment
+from .functions import Functions as Functions
+from .layers import Layers as Layers
+from .observability import Observability as Observability
+from .orchestration import Orchestration as Orchestration
 ```
 
 ## ブランチとコミットメッセージ


### PR DESCRIPTION
コード側で__all__を廃止し冗長エイリアス方式に移行済みのため、
設計書(02〜11)のコード例も同じ方針に合わせる。