### PR TITLE
fix: StateMachineのdefinitionをdefinition_bodyに移行し非推奨警告を解消

### DIFF
--- a/infra/constructs/orchestration.py
+++ b/infra/constructs/orchestration.py
@@ -40,5 +40,7 @@ class Orchestration(Construct):
         )
 
         self.state_machine = sfn.StateMachine(
-            self, "TripBookingStateMachine", definition=definition
+            self,
+            "TripBookingStateMachine",
+            definition_body=sfn.DefinitionBody.from_chainable(definition),
         )


### PR DESCRIPTION
### Summary

  - cdk synth 実行時に出力されていた StateMachineProps#definition is deprecated 警告を解消
  - definition パラメータを definition_body: DefinitionBody.from_chainable() に移行

### Background

  aws-cdk-lib の StateMachine コンストラクタで definition パラメータが非推奨となり、次のメジャーバージョンで削除予定。

```
  [WARNING] aws-cdk-lib.aws_stepfunctions.StateMachineProps#definition is deprecated.
    use definitionBody: DefinitionBody.fromChainable()
    This API will be removed in the next major release.
```