### PR TITLE
feat: GSI定義と各RepositoryへのGSI属性書き込みを追加

### DIFF
--- a/infra/constructs/database.py
+++ b/infra/constructs/database.py
@@ -1,9 +1,5 @@
-from aws_cdk import (
-    RemovalPolicy,
-)
-from aws_cdk import (
-    aws_dynamodb as dynamodb,
-)
+from aws_cdk import RemovalPolicy
+from aws_cdk import aws_dynamodb as dynamodb
 from constructs import Construct
 
 
@@ -22,4 +18,14 @@ class Database(Construct):
             sort_key=dynamodb.Attribute(name="SK", type=dynamodb.AttributeType.STRING),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             removal_policy=RemovalPolicy.DESTROY,
+        )
+
+        self.table.add_global_secondary_index(
+            index_name="GSI1",
+            partition_key=dynamodb.Attribute(
+                name="GSI1PK", type=dynamodb.AttributeType.STRING
+            ),
+            sort_key=dynamodb.Attribute(
+                name="GSI1SK", type=dynamodb.AttributeType.STRING
+            ),
         )

--- a/src/services/flight/infrastructure/dynamodb_booking_repository.py
+++ b/src/services/flight/infrastructure/dynamodb_booking_repository.py
@@ -36,6 +36,8 @@ class DynamoDBBookingRepository(BookingRepository):
             "price_amount": str(booking.price.amount),
             "price_currency": str(booking.price.currency),
             "status": booking.status.value,
+            "GSI1PK": "TRIPS",
+            "GSI1SK": f"TRIP#{booking.trip_id}",
         }
         try:
             self.table.put_item(

--- a/src/services/hotel/infrastructure/dynamodb_hotel_booking_repository.py
+++ b/src/services/hotel/infrastructure/dynamodb_hotel_booking_repository.py
@@ -35,6 +35,8 @@ class DynamoDBHotelBookingRepository(HotelBookingRepository):
             "price_amount": str(booking.price.amount),
             "price_currency": str(booking.price.currency),
             "status": booking.status.value,
+            "GSI1PK": "TRIPS",
+            "GSI1SK": f"TRIP#{booking.trip_id}",
         }
         try:
             self.table.put_item(

--- a/src/services/payment/infrastructure/dynamodb_payment_repository.py
+++ b/src/services/payment/infrastructure/dynamodb_payment_repository.py
@@ -32,6 +32,8 @@ class DynamoDBPaymentRepository(PaymentRepository):
             "amount": str(payment.amount.amount),
             "currency": str(payment.amount.currency),
             "status": payment.status.value,
+            "GSI1PK": "TRIPS",
+            "GSI1SK": f"TRIP#{payment.trip_id}",
         }
         try:
             self.table.put_item(


### PR DESCRIPTION
DynamoDBテーブルにGSI1(GSI1PK/GSI1SK)を定義し、
Flight/Hotel/Payment各Repositoryの保存アイテムに
GSI1PK="TRIPS"とGSI1SK="TRIP#<trip_id>"を追加。
これによりGSI経由でのTrip一覧取得が可能になる。