### PR TITLE
typing.Optionalをパイプ構文(X | None)に置換

### DIFF
--- a/src/services/flight/domain/repository/booking_repository.py
+++ b/src/services/flight/domain/repository/booking_repository.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from typing import Optional
 
 from services.flight.domain.entity import Booking
 from services.flight.domain.value_object import BookingId
@@ -15,11 +14,11 @@ class BookingRepository(Repository[Booking, BookingId]):
         raise NotImplementedError
 
     @abstractmethod
-    def find_by_id(self, booking_id: BookingId) -> Optional[Booking]:
+    def find_by_id(self, booking_id: BookingId) -> Booking | None:
         """予約IDで検索"""
         raise NotImplementedError
 
     @abstractmethod
-    def find_by_trip_id(self, tripId: TripId) -> Optional[Booking]:
+    def find_by_trip_id(self, tripId: TripId) -> Booking | None:
         """TripIDで検索"""
         raise NotImplementedError

--- a/src/services/flight/handlers/reserve.py
+++ b/src/services/flight/handlers/reserve.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.parser import event_parser
 from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -78,9 +76,7 @@ def _to_response(booking: Booking) -> dict:
     ).model_dump()
 
 
-def _error_response(
-    error_code: str, message: str, details: Optional[list] = None
-) -> dict:
+def _error_response(error_code: str, message: str, details: list | None = None) -> dict:
     """エラーレスポンスを生成"""
     return ErrorResponse(
         error_code=error_code,

--- a/src/services/flight/infrastructure/dynamodb_booking_repository.py
+++ b/src/services/flight/infrastructure/dynamodb_booking_repository.py
@@ -1,6 +1,5 @@
 import os
 from decimal import Decimal
-from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -16,7 +15,7 @@ from services.shared.domain.exception.exceptions import DuplicateResourceExcepti
 class DynamoDBBookingRepository(BookingRepository):
     """DynamoDBを使用したBookingRepository の具象実装"""
 
-    def __init__(self, table_name: Optional[str] = None) -> None:
+    def __init__(self, table_name: str | None = None) -> None:
         self.table_name = table_name or os.getenv("TABLE_NAME")
         self.dynamodb = boto3.resource("dynamodb")
         self.table = self.dynamodb.Table(self.table_name)
@@ -49,7 +48,7 @@ class DynamoDBBookingRepository(BookingRepository):
                     f"Booking already exists: {booking.id}"
                 )
 
-    def find_by_id(self, booking_id: BookingId) -> Optional[Booking]:
+    def find_by_id(self, booking_id: BookingId) -> Booking | None:
         """予約IDで検索"""
         trip_id = str(booking_id).removeprefix("flight_for_#")
         response = self.table.get_item(
@@ -63,7 +62,7 @@ class DynamoDBBookingRepository(BookingRepository):
             return None
         return self._to_entity(item)
 
-    def find_by_trip_id(self, trip_id: TripId) -> Optional[Booking]:
+    def find_by_trip_id(self, trip_id: TripId) -> Booking | None:
         """Trip ID でフライト予約を検索する"""
         response = self.table.query(
             KeyConditionExpression="PK = :pk AND begins_with(SK, :sk_prefix)",

--- a/src/services/hotel/domain/repository/hotel_booking_repository.py
+++ b/src/services/hotel/domain/repository/hotel_booking_repository.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from typing import Optional
 
 from services.hotel.domain.entity.hotel_booking import HotelBooking
 from services.hotel.domain.value_object.hotel_booking_id import HotelBookingId
@@ -15,11 +14,11 @@ class HotelBookingRepository(Repository[HotelBooking, HotelBookingId]):
         raise NotImplementedError
 
     @abstractmethod
-    def find_by_id(self, booking_id: HotelBookingId) -> Optional[HotelBooking]:
+    def find_by_id(self, booking_id: HotelBookingId) -> HotelBooking | None:
         """予約IDで検索する"""
         raise NotImplementedError
 
     @abstractmethod
-    def find_by_trip_id(self, trip_id: TripId) -> Optional[HotelBooking]:
+    def find_by_trip_id(self, trip_id: TripId) -> HotelBooking | None:
         """TripIDで検索する"""
         raise NotImplementedError

--- a/src/services/hotel/handlers/reserve.py
+++ b/src/services/hotel/handlers/reserve.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.parser import event_parser
 from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -44,9 +42,7 @@ def _to_response(booking: HotelBooking) -> dict:
     ).model_dump()
 
 
-def _error_response(
-    error_code: str, message: str, details: Optional[list] = None
-) -> dict:
+def _error_response(error_code: str, message: str, details: list | None = None) -> dict:
     """エラーレスポンスを生成"""
     return ErrorResponse(
         error_code=error_code,

--- a/src/services/hotel/infrastructure/dynamodb_hotel_booking_repository.py
+++ b/src/services/hotel/infrastructure/dynamodb_hotel_booking_repository.py
@@ -1,6 +1,5 @@
 import os
 from decimal import Decimal
-from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -16,7 +15,7 @@ from services.shared.domain.exception.exceptions import DuplicateResourceExcepti
 class DynamoDBHotelBookingRepository(HotelBookingRepository):
     """DynamoDBを使用したHotelBookingRepository の具象実装"""
 
-    def __init__(self, table_name: Optional[str] = None) -> None:
+    def __init__(self, table_name: str | None = None) -> None:
         self.table_name = table_name or os.getenv("TABLE_NAME")
         self.dynamodb = boto3.resource("dynamodb")
         self.table = self.dynamodb.Table(self.table_name)
@@ -48,7 +47,7 @@ class DynamoDBHotelBookingRepository(HotelBookingRepository):
                     f"Hotel booking already exists: {booking.id}"
                 )
 
-    def find_by_id(self, booking_id: HotelBookingId) -> Optional[HotelBooking]:
+    def find_by_id(self, booking_id: HotelBookingId) -> HotelBooking | None:
         """予約IDで検索"""
         trip_id = str(booking_id).removeprefix("hotel_for_")
         response = self.table.get_item(
@@ -62,7 +61,7 @@ class DynamoDBHotelBookingRepository(HotelBookingRepository):
             return None
         return self._to_entity(item)
 
-    def find_by_trip_id(self, trip_id: TripId) -> Optional[HotelBooking]:
+    def find_by_trip_id(self, trip_id: TripId) -> HotelBooking | None:
         """Trip ID でホテル予約を検索する"""
         response = self.table.query(
             KeyConditionExpression="PK = :pk AND begins_with(SK, :sk_prefix)",

--- a/src/services/payment/domain/repository/payment_repository.py
+++ b/src/services/payment/domain/repository/payment_repository.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from typing import Optional
 
 from services.payment.domain.entity.payment import Payment
 from services.payment.domain.value_object.payment_id import PaymentId
@@ -15,11 +14,11 @@ class PaymentRepository(Repository[Payment, PaymentId]):
         raise NotImplementedError
 
     @abstractmethod
-    def find_by_id(self, payment_id: PaymentId) -> Optional[Payment]:
+    def find_by_id(self, payment_id: PaymentId) -> Payment | None:
         """決済IDで検索する"""
         raise NotImplementedError
 
     @abstractmethod
-    def find_by_trip_id(self, trip_id: TripId) -> Optional[Payment]:
+    def find_by_trip_id(self, trip_id: TripId) -> Payment | None:
         """Trip ID で検索する"""
         raise NotImplementedError

--- a/src/services/payment/infrastructure/dynamodb_payment_repository.py
+++ b/src/services/payment/infrastructure/dynamodb_payment_repository.py
@@ -1,6 +1,5 @@
 import os
 from decimal import Decimal
-from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -16,7 +15,7 @@ from services.shared.domain.exception.exceptions import DuplicateResourceExcepti
 class DynamoDBPaymentRepository(PaymentRepository):
     """DynamoDBを使用したPaymentRepository の具象実装"""
 
-    def __init__(self, table_name: Optional[str] = None) -> None:
+    def __init__(self, table_name: str | None = None) -> None:
         self.table_name = table_name or os.getenv("TABLE_NAME")
         self.dynamodb = boto3.resource("dynamodb")
         self.table = self.dynamodb.Table(self.table_name)
@@ -45,7 +44,7 @@ class DynamoDBPaymentRepository(PaymentRepository):
                     f"Payment already exists: {payment.id}"
                 )
 
-    def find_by_id(self, payment_id: PaymentId) -> Optional[Payment]:
+    def find_by_id(self, payment_id: PaymentId) -> Payment | None:
         """決済IDで検索"""
         response = self.table.scan(
             FilterExpression="payment_id = :pid",
@@ -56,7 +55,7 @@ class DynamoDBPaymentRepository(PaymentRepository):
             return None
         return self._to_entity(items[0])
 
-    def find_by_trip_id(self, trip_id: TripId) -> Optional[Payment]:
+    def find_by_trip_id(self, trip_id: TripId) -> Payment | None:
         """Trip ID で決済を検索する"""
         response = self.table.query(
             KeyConditionExpression="PK = :pk AND begins_with(SK, :sk_prefix)",

--- a/src/services/shared/domain/repository/repository.py
+++ b/src/services/shared/domain/repository/repository.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 T = TypeVar("T")
 ID = TypeVar("ID")
@@ -17,6 +17,6 @@ class Repository(ABC, Generic[T, ID]):
         raise NotImplementedError
 
     @abstractmethod
-    def find_by_id(self, id: ID) -> Optional[T]:
+    def find_by_id(self, id: ID) -> T | None:
         """IDで集約を検索する"""
         raise NotImplementedError


### PR DESCRIPTION
Python 3.10+で推奨されるPEP 604のunion型構文に統一し、
不要になったtyping.Optionalのインポートを削除