### PR TITLE
app.pyから直接デプロイ用のServerlessTripSagaStackを削除

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,13 +3,8 @@
 import aws_cdk as cdk
 
 from pipeline_stack import PipelineStack
-from serverless_trip_saga_stack import ServerlessTripSagaStack
 
 app = cdk.App()
-ServerlessTripSagaStack(
-    app,
-    "ServerlessTripSagaStack",
-)
 
 PipelineStack(app, "PipelineStack")
 


### PR DESCRIPTION
パイプライン経由のProdスタックに一本化し、重複リソースの発生を防止する