### PR TITLE
fix: Step Functionsのエラーハンドリング修正のため例外を送出するように変更

### DIFF
--- a/src/services/flight/handlers/reserve.py
+++ b/src/services/flight/handlers/reserve.py
@@ -9,7 +9,6 @@ from services.flight.domain.factory.booking_factory import FlightDetails
 from services.flight.handlers.request_models import ReserveFlightRequest
 from services.flight.handlers.response_models import (
     BookingData,
-    ErrorResponse,
     SuccessResponse,
 )
 from services.flight.infrastructure.dynamodb_booking_repository import (
@@ -38,14 +37,10 @@ def lambda_handler(event: ReserveFlightRequest, context: LambdaContext) -> dict:
 
     logger.info("Received reserve flight request")
 
-    try:
-        trip_id = TripId(value=event.trip_id)
-        flight_details = _to_flight_details(event)
-        booking = service.reserve(trip_id, flight_details)
-        return _to_response(booking)
-    except Exception as e:
-        logger.exception("Failed to reserve flight")
-        return _error_response("INTERNAL_ERROR", str(e))
+    trip_id = TripId(value=event.trip_id)
+    flight_details = _to_flight_details(event)
+    booking = service.reserve(trip_id, flight_details)
+    return _to_response(booking)
 
 
 def _to_flight_details(request: ReserveFlightRequest) -> FlightDetails:
@@ -74,12 +69,3 @@ def _to_response(booking: Booking) -> dict:
             status=booking.status.value,
         )
     ).model_dump()
-
-
-def _error_response(error_code: str, message: str, details: list | None = None) -> dict:
-    """エラーレスポンスを生成"""
-    return ErrorResponse(
-        error_code=error_code,
-        message=message,
-        details=details,
-    ).model_dump(exclude_none=True)

--- a/src/services/hotel/handlers/reserve.py
+++ b/src/services/hotel/handlers/reserve.py
@@ -8,7 +8,6 @@ from services.hotel.domain.factory import HotelBookingFactory
 from services.hotel.domain.factory.hotel_booking_factory import HotelDetails
 from services.hotel.handlers.request_models import ReserveHotelRequest
 from services.hotel.handlers.response_models import (
-    ErrorResponse,
     HotelBookingData,
     SuccessResponse,
 )
@@ -42,33 +41,19 @@ def _to_response(booking: HotelBooking) -> dict:
     ).model_dump()
 
 
-def _error_response(error_code: str, message: str, details: list | None = None) -> dict:
-    """エラーレスポンスを生成"""
-    return ErrorResponse(
-        error_code=error_code,
-        message=message,
-        details=details,
-    ).model_dump(exclude_none=True)
-
-
 @logger.inject_lambda_context
 @event_parser(model=ReserveHotelRequest)
 def lambda_handler(event: ReserveHotelRequest, context: LambdaContext) -> dict:
     """ホテル予約 Lambda ハンドラ"""
     logger.info("Received reserve hotel request")
 
-    try:
-        trip_id = TripId(value=event.trip_id)
-        hotel_details: HotelDetails = {
-            "hotel_name": event.hotel_details.hotel_name,
-            "check_in_date": event.hotel_details.check_in_date,
-            "check_out_date": event.hotel_details.check_out_date,
-            "price_amount": event.hotel_details.price_amount,
-            "price_currency": event.hotel_details.price_currency,
-        }
-        booking = service.reserve(trip_id, hotel_details)
-        return _to_response(booking)
-
-    except Exception as e:
-        logger.exception("Failed to reserve hotel")
-        return _error_response("INTERNAL_ERROR", str(e))
+    trip_id = TripId(value=event.trip_id)
+    hotel_details: HotelDetails = {
+        "hotel_name": event.hotel_details.hotel_name,
+        "check_in_date": event.hotel_details.check_in_date,
+        "check_out_date": event.hotel_details.check_out_date,
+        "price_amount": event.hotel_details.price_amount,
+        "price_currency": event.hotel_details.price_currency,
+    }
+    booking = service.reserve(trip_id, hotel_details)
+    return _to_response(booking)

--- a/src/services/payment/handlers/process.py
+++ b/src/services/payment/handlers/process.py
@@ -7,7 +7,6 @@ from services.payment.domain.entity import Payment
 from services.payment.domain.factory import PaymentFactory
 from services.payment.handlers.request_models import ProcessPaymentRequest
 from services.payment.handlers.response_models import (
-    ErrorResponse,
     PaymentData,
     SuccessResponse,
 )
@@ -36,30 +35,16 @@ def _to_response(payment: Payment) -> dict:
     ).model_dump()
 
 
-def _error_response(error_code: str, message: str, details: list | None = None) -> dict:
-    """エラーレスポンスを生成"""
-    return ErrorResponse(
-        error_code=error_code,
-        message=message,
-        details=details,
-    ).model_dump(exclude_none=True)
-
-
 @logger.inject_lambda_context
 @event_parser(model=ProcessPaymentRequest)
 def lambda_handler(event: ProcessPaymentRequest, context: LambdaContext) -> dict:
     """決済処理のLambdaハンドラー"""
     logger.info("Received process payment request")
 
-    try:
-        trip_id = TripId(value=event.trip_id)
-        payment = service.process(
-            trip_id=trip_id,
-            amount=event.amount,
-            currency_code=event.currency,
-        )
-        return _to_response(payment)
-
-    except Exception as e:
-        logger.exception("Failed to process payment")
-        return _error_response("INTERNAL_ERROR", str(e))
+    trip_id = TripId(value=event.trip_id)
+    payment = service.process(
+        trip_id=trip_id,
+        amount=event.amount,
+        currency_code=event.currency,
+    )
+    return _to_response(payment)


### PR DESCRIPTION
SagaパターンにおいてStep FunctionsのCatchブロックが機能しない問題を修正。
これまではLambdaハンドラー内で例外を捕捉しエラーJSONを返却していたため、
Step Functions側でTaskFailedとして検知されず、補償トランザクションが実行されなかった。

変更内容:
- Flight, Hotel, Paymentサービスのハンドラーからtry-exceptブロックを削除
- 例外発生時にそのままthrowさせることでStep Functionsにエラーを伝播させる