### PR TITLE
fix: IsoDateTime.__str__がdatetimeオブジェクトを返すバグを修正

### DIFF
--- a/src/services/shared/domain/value_object/iso_date_time.py
+++ b/src/services/shared/domain/value_object/iso_date_time.py
@@ -20,7 +20,7 @@ class IsoDateTime:
         return cls(value=dt)
 
     def __str__(self) -> str:
-        return self.value
+        return self.value.isoformat()
 
     def is_before(self, other: IsoDateTime) -> bool:
         """他の日時より前かどうか"""


### PR DESCRIPTION
__str__メソッドがself.value(datetime型)をそのまま返していたため、
str()呼び出し時にTypeErrorが発生し、フライト予約のDynamoDB保存が失敗していた。 self.value.isoformat()に修正し、ISO 8601形式の文字列を返すようにした。