### PR TITLE
docs: Datadog可観測性ガイドと検証用イベントの追加

### DIFF
--- a/docs/hands-on/12_e2e_verification_and_chaos.md
+++ b/docs/hands-on/12_e2e_verification_and_chaos.md
@@ -1,0 +1,239 @@
+# Hands-on 12: E2E Verification & Chaos Testing
+
+本セクションでは、構築した Saga オーケストレーションの動作確認を行います。
+正常系のシナリオだけでなく、意図的にエラーを発生させる「カオスエンジニアリング」の手法を用いて、補償トランザクション（ロールバック処理）が正しく機能することを検証します。
+
+また、API Gateway を経由した外部からのリクエスト実行検証や、分散システム特有の「重複実行（冪等性）」の確認も行います。
+
+## 目的
+
+1.  **正常系**: 全ての予約処理（フライト、ホテル、決済）が完了し、データ整合性が保たれていることを確認する。
+2.  **異常系 (Payment Fail)**: 決済失敗時に、既に完了したフライトとホテルの予約が自動的にキャンセルされることを確認する。
+3.  **異常系 (Hotel Fail)**: ホテル予約失敗時に、既に完了したフライト予約がキャンセルされることを確認する。
+4.  **API Gateway**: 外部公開されたエンドポイント経由でワークフローを開始できることを確認する。
+5.  **重複実行**: 同じリクエストを再度送信した際の挙動を確認する。
+
+## 前提条件
+
+*   `cdk deploy` が完了していること。
+*   検証用 JSON ファイルが `events/` ディレクトリに配置されていること。
+*   AWS CLI, `curl`, `jq` が実行可能であること。
+*   Datadog アカウントにアクセス可能であること（可観測性の確認のため）。
+
+## 1. 環境変数の設定
+
+検証コマンドを簡略化するため、Step Functions の ARN と DynamoDB テーブル名、API Gateway URL を環境変数に設定します。
+
+```bash
+# Step Functions ARN の取得
+export STATE_MACHINE_ARN=$(aws stepfunctions list-state-machines --query "stateMachines[?contains(name, 'TripBookingStateMachine')].stateMachineArn" --output text)
+echo "State Machine ARN: $STATE_MACHINE_ARN"
+
+# DynamoDB テーブル名の取得 (BookingTable -> TripTable に修正)
+export BOOKING_TABLE_NAME=$(aws dynamodb list-tables --query "TableNames[?contains(@, 'TripTable')]" --output text)
+echo "Booking Table Name: $BOOKING_TABLE_NAME"
+
+# API Gateway URL の取得 (Stack名依存を排除し、API名から直接取得)
+export API_URL=$(aws apigatewayv2 get-apis --query "Items[?Name=='Trip Booking API'].ApiEndpoint" --output text)
+echo "API URL: $API_URL"
+```
+
+## 2. 正常系シナリオ (Happy Path) - Step Functions 直接実行
+
+まずは AWS CLI を使って Step Functions を直接実行し、ロジックの正当性を確認します。
+
+### 2.1 実行
+
+```bash
+aws stepfunctions start-execution \
+    --state-machine-arn $STATE_MACHINE_ARN \
+    --name "Verification-Success-$(date +%s)" \
+    --input file://events/sfn_input_success.json
+```
+
+### 2.2 結果確認 (AWS Console & CLI)
+
+ステータスが `SUCCEEDED` になるまで待ちます。
+
+```bash
+# 最新の実行結果を取得
+aws stepfunctions list-executions \
+    --state-machine-arn $STATE_MACHINE_ARN \
+    --max-items 1
+```
+
+**AWS Console での確認方法:**
+1.  Step Functions コンソールを開く。
+2.  `TripBookingStateMachine` を選択。
+3.  最新の実行（Verification-Success-...）をクリック。
+4.  **Graph View** で、全てのステップが緑色（成功）になっていることを確認。
+
+### 2.3 データ確認 (DynamoDB)
+
+予約データが「確定 (CONFIRMED / COMPLETED)」状態で保存されていることを確認します。
+
+```bash
+aws dynamodb scan \
+    --table-name $BOOKING_TABLE_NAME \
+    --filter-expression "PK = :pk" \
+    --expression-attribute-values '{":pk": {"S": "TRIP#trip-success-001"}}'
+```
+> **期待値**: 全てのアイテム（FLIGHT, HOTEL, PAYMENT）が存在し、status が `CONFIRMED` または `COMPLETED` であること。
+
+### 2.4 可観測性の確認 (Datadog)
+
+この実行が Datadog でどのように見えるかを確認します。
+
+1.  **Datadog > Serverless > Step Functions** を開く。
+2.  `OrchestrationTripBookingStateMachine` を選択。
+3.  画面下部の **Executions** タブから、先ほどの実行を選択。
+4.  **Flame Graph** で、Step Functions -> 各 Lambda (ReserveFlight, ReserveHotel, ProcessPayment) の呼び出しが繋がっていることを確認する。
+5.  もし Lambda のログが見たい場合、Flame Graph 上の Lambda Span をクリックし、Logs タブを選択する。
+
+## 3. 正常系シナリオ - API Gateway 経由実行
+
+次に、API Gateway のエンドポイント (`POST /trips`) を叩いてワークフローを開始します。
+これは Web フロントエンドやモバイルアプリからの利用を想定したシナリオです。
+
+### 3.1 リクエスト形式について
+現在、API Gateway にはマッピングテンプレート (VTL) が設定されています。
+これにより、クライアントは純粋な JSON データを送信するだけで、API Gateway が自動的に Step Functions の入力形式に変換してくれます。
+面倒な JSON のエスケープ処理 (`{\"input\": ...}`) は不要になりました。
+
+**送信するデータ:**
+```json
+{ "trip_id": "trip-api-001", ... }
+```
+
+### 3.2 実行 (curl)
+
+`jq` コマンドで JSON ファイルを読み込み、そのまま API Gateway へ送信します。
+
+```bash
+# 1. 検証用データの trip_id をユニークなものに変更 (衝突回避)
+jq '.trip_id = "trip-api-success-001"' events/sfn_input_success.json > events/sfn_input_api.json
+
+# 2. curl で POST リクエスト送信
+# 以前のような複雑な jq 処理は不要です
+curl -X POST "$API_URL/trips" \
+  -H "Content-Type: application/json" \
+  -d @events/sfn_input_api.json
+```
+
+### 3.3 結果確認
+
+API からは `executionArn` と `startDate` が返却されます。
+
+**AWS Console での確認 (CloudWatch):**
+現在の設定では、API Gateway のログは Datadog に転送されていません（別途設定が必要）。そのため、AWS コンソールで確認します。
+
+1.  **API Gateway コンソール** を開く。
+2.  `Trip Booking API` を選択 -> **Monitor** タブを見る。
+3.  または、CloudWatch Logs で `/aws/apigateway/...` (設定されている場合) のロググループを確認する。
+    *   ※今回のハンズオン構成 (`HttpApi`) ではデフォルトでアクセスログが無効になっている場合があります。その場合は、Step Functions 側で実行が開始されたこと (`executionArn` が返ること) をもって成功とみなします。
+
+**Datadog での確認 (Step Functions):**
+API Gateway のログは見れませんが、そこからキックされた Step Functions の実行は Datadog で確認できます。
+
+1.  **Datadog > Serverless > Step Functions**。
+2.  新しい実行履歴（Start time が直近のもの）が表示されていることを確認。
+
+## 4. 重複実行の検証 (Idempotency Check)
+
+分散システムでは、ネットワーク遅延などにより同じリクエストが複数回到達する可能性があります。
+ここでは、既に成功したリクエストと同じ `trip_id` で再度実行した場合の挙動を確認します。
+
+### 4.1 実行
+
+先ほど成功した `trip-success-001` を入力として、再度実行します。
+
+```bash
+aws stepfunctions start-execution \
+    --state-machine-arn $STATE_MACHINE_ARN \
+    --name "Verification-Duplicate-$(date +%s)" \
+    --input file://events/sfn_input_success.json
+```
+
+### 4.2 結果確認
+
+実行ステータスを確認します。
+
+```bash
+aws stepfunctions list-executions \
+    --state-machine-arn $STATE_MACHINE_ARN \
+    --max-items 1
+```
+
+> **期待値**: ステータスは `FAILED` になります。
+> **理由**: DynamoDB への書き込み時に `ConditionalCheckFailedException`（重複エラー）が発生するため。
+
+**Datadog での確認:**
+1.  Datadog でこの実行 (`FAILED`) を探す。
+2.  エラーになっている Lambda (ReserveFlight) のログを確認する。
+3.  `ConditionalCheckFailedException` というエラーログが出力されていることを確認する。
+
+## 5. 異常系シナリオ: 決済失敗 (Saga Compensation - Payment)
+
+ここからは異常系の動作確認です。
+`amount` に負の値 (`-1`) を設定することで、バリデーションエラーを誘発させます。
+
+### 5.1 実行
+
+```bash
+aws stepfunctions start-execution \
+    --state-machine-arn $STATE_MACHINE_ARN \
+    --name "Verification-PaymentFail-$(date +%s)" \
+    --input file://events/sfn_input_payment_fail.json
+```
+
+### 5.2 結果確認
+
+Step Functions の実行ステータスは `FAILED` になりますが、Graph View で補償フローが実行されたことを確認します。
+
+**Datadog での確認:**
+1.  Flame Graph を見る。
+2.  `ProcessPayment` がエラー（赤色）になっている。
+3.  その後に `CancelHotel` -> `CancelFlight` が順次実行されている（補償トランザクション）様子を確認する。
+
+### 5.3 データ確認 (DynamoDB)
+
+予約データが「キャンセル済み (CANCELLED)」状態に変更されていることを確認します。
+
+```bash
+aws dynamodb scan \
+    --table-name $BOOKING_TABLE_NAME \
+    --filter-expression "PK = :pk" \
+    --expression-attribute-values '{":pk": {"S": "TRIP#trip-payment-fail-001"}}'
+```
+
+## 6. 異常系シナリオ: ホテル予約失敗 (Saga Compensation - Hotel)
+
+ホテル予約でエラー（例: 日付不正）が発生した場合をシミュレーションします。
+
+### 6.1 実行
+
+```bash
+aws stepfunctions start-execution \
+    --state-machine-arn $STATE_MACHINE_ARN \
+    --name "Verification-HotelFail-$(date +%s)" \
+    --input file://events/sfn_input_hotel_fail.json
+```
+
+### 6.2 データ確認 (DynamoDB)
+
+```bash
+aws dynamodb scan \
+    --table-name $BOOKING_TABLE_NAME \
+    --filter-expression "PK = :pk" \
+    --expression-attribute-values '{":pk": {"S": "TRIP#trip-hotel-fail-001"}}'
+```
+> **期待値**: `FLIGHT#...` のレコードの status が `CANCELLED` になっていること。
+
+## 7. まとめ
+
+これで、Step Functions 直接実行、API Gateway 経由実行、そして重複実行時の挙動検証が完了しました。
+Saga パターンの整合性と、外部インターフェースの疎通確認が取れました。
+また、AWS Console と Datadog の両方を使って、実行結果やエラー原因を追跡する方法も学びました。
+
+さらに深い可観測性のテクニックについては、次章を参照してください。
+👉 **[Hands-on 13: Advanced Observability with Datadog](./13_advanced_observability_datadog.md)** へ進む

--- a/docs/hands-on/13_advanced_observability_datadog.md
+++ b/docs/hands-on/13_advanced_observability_datadog.md
@@ -1,0 +1,227 @@
+# Hands-on 13: The Bible of Serverless Observability with Datadog (Enterprise Scale)
+
+## はじめに: 500関数の「カオス」を支配する
+
+Lambda関数が10個程度の環境と、500個を超える大規模環境では、可観測性の次元が異なります。
+小規模ならGUIで一つずつ設定できますが、大規模環境では「自動化」「コード化」「統制」がなければ運用は破綻します。
+
+本ガイドは、**「大規模Serverlessアーキテクチャ」** における Datadog の実践的かつ高度な運用マニュアルです。
+WebエンジニアがSREとして現場に入った初日から「プロフェッショナル」として振る舞うために必要な、**IaC、コスト管理、セキュリティ、高度なデバッグ技術**を網羅しています。
+
+---
+
+## Chapter 1: Observability as Code (監視のコード化)
+
+500個のLambdaに対して、ブラウザでモニターを作るのは自殺行為です。
+**「ダッシュボードもモニターも、全てコード（Terraform/CDK）で管理する」** ことが、大規模環境の絶対条件です。
+
+### 1.1 Datadog Provider for Terraform / CDK
+インフラと同じプルリクエストで、監視設定もレビュー・デプロイされるべきです。
+
+**【実践コード例 (Terraform)】**
+「全てのLambdaにエラーレートのアラートを自動設定する」モジュールのイメージ。
+
+```hcl
+resource "datadog_monitor" "lambda_error_rate" {
+  name    = "[${var.env}] Lambda Error Rate High: {{service.name}}"
+  type    = "query alert"
+  query   = "avg(last_5m):default_zero(sum:aws.lambda.errors{env:${var.env}, service:${var.service_name}}) / default_zero(sum:aws.lambda.invocations{env:${var.env}, service:${var.service_name}}) > 0.05"
+  message = <<EOT
+  {{service.name}} のエラー率が5%を超えました。
+  Logs: [Dashboard Link]
+  @slack-${var.team_channel}
+  EOT
+  
+  tags = ["env:${var.env}", "service:${var.service_name}", "terraform:true"]
+}
+```
+
+### 1.2 "Monitor Json" Pattern
+Terraformのリソース定義だけでは複雑なダッシュボードを表現しきれない場合、DatadogのUIで作成したダッシュボードのJSONをエクスポートし、それをコードリポジトリで管理・インポートする手法も有効です。
+
+---
+
+## Chapter 2: Advanced Tracing Strategy (高度なトレース戦略)
+
+リクエスト数が億単位になると、全トレース取得は経済的にも技術的にも不可能です。
+「何を捨て、何を残すか」の意思決定がSREの腕の見せ所です。
+
+### 2.1 Trace Context Propagation (コンテキスト伝播の完全化)
+SQS, EventBridge, Kinesis などを経由する非同期アーキテクチャでは、デフォルト設定だけではトレースが分断されます。
+
+*   **鉄則**: `aws-lambda-powertools` (Python) または `datadog-lambda` レイヤーを使用し、分散トレーシングを有効化。
+*   **環境変数**: `DD_TRACE_ENABLED=true`, `DD_LOGS_INJECTION=true`
+
+### 2.2 Intelligent Sampling (サンプリング戦略)
+*   **Head-based Sampling**: API Gatewayなどの入り口で `DD_TRACE_SAMPLE_RATE` を設定（Prod: 5-10%）。
+*   **Retention Filters (Tag-based)**:
+    *   「エラーが発生したトレース」は **100% 保持**。
+    *   「特定の重要顧客（`customer_id:premium`）」のトレースは **100% 保持**。
+    *   それ以外はランダムサンプリング。
+    *   これらを **Datadog UI上の "Retention Filters"** で設定します（コード変更不要）。
+
+---
+
+## Chapter 3: Log Management & Cost Control (ログ管理とコスト最適化)
+
+「ログは全て保存する」は破産への近道です。ログの価値に応じて保存先を振り分けます。
+
+### 3.1 Exclusion Filters & Indexing Strategy
+Lambdaの標準出力は膨大です。以下の戦略でコストを90%削減します。
+
+1.  **Exclude from Index**: `START RequestId`, `END RequestId`, `REPORT RequestId` などのAWS基盤ログは、Index（検索対象）から除外し、Live Tailのみで見えるように設定。
+2.  **Log Archives**: コンプライアンス上保存が必要だが、普段は見ないログ（正常系のアクセスログなど）は、**S3へのアーカイブ（Log Archives）** に送る。Datadogには保存しない。
+3.  **Rehydration**: アーカイブしたログが必要になった時だけ、特定の時間帯・クエリでDatadogに書き戻す機能を使用。
+
+### 3.2 Sensitive Data Masking (PII保護)
+ログにクレジットカード番号や個人情報が含まれると大事故です。
+**Scanner** プロセッサを設定し、正規表現でPII（個人特定情報）を検出し、Datadog保存前にハッシュ化または置換（Redact）します。
+
+---
+
+## Chapter 4: Database & Dependency Deep Dive (DBと依存関係)
+
+Lambdaが遅い原因の7割はDBか外部APIです。
+
+### 4.1 DynamoDB Hot Partition & Throttling
+AWS統合メトリクスだけでなく、アプリケーション側からの視点を強化します。
+
+*   **Metric**: `aws.dynamodb.provisioned_throughput_exceeded` だけでは不十分。
+*   **Span Tags**: アプリケーションのSpanに `db.statement` (実行したクエリ), `table_name` を付与し、どのクエリが遅いかを特定できるようにする。
+
+### 4.2 External API Monitoring
+決済GWや他社APIへの依存はリスクです。
+*   外部APIへのHTTPリクエストを `service:payment-gateway` のように仮想サービスとして定義し、その **Availability (可用性)** と **Latency** を個別に監視します。
+
+---
+
+## Chapter 5: Continuous Profiler (コードレベルの深掘り)
+
+「なぜか遅い」「メモリリークしている」といった、ログやトレースでは分からない問題には **Continuous Profiler** が必須です。
+
+### 5.1 本番環境での常時プロファイリング
+オーバーヘッドは極めて低いため、本番でも有効化します。
+
+*   **Wall Time Profiling**: I/O待ち（DB応答待ちなど）の時間内訳。
+*   **CPU Profiling**: 高負荷な計算処理（画像の加工、暗号化など）の特定。
+*   **Memory Profiling**: メモリリークや非効率なオブジェクト生成の特定。
+
+これにより、「この関数の30行目のループ処理がCPUの40%を消費している」といったレベルまで特定できます。
+
+---
+
+## Chapter 6: Intelligent Alerting & SLO (アラート戦略)
+
+### 6.1 SLO (Service Level Objectives) & Burn Rate
+「エラーが出た」でアラートを飛ばすのは二流です。「ユーザーとの約束（SLO）が破られそうだ」で飛ばします。
+
+*   **SLO**: 99.9% の成功率（月間ダウンタイム許容: 約43分）。
+*   **Burn Rate Alert**: 「このままのペースでエラーが続くと、あと2時間でエラー予算が尽きる」という速度（Burn Rate）を検知してアラート。これにより、散発的なエラーでの深夜の叩き起こしを防ぎます。
+
+### 6.2 Composite Monitors
+誤検知を防ぐ最強の武器です。
+*   Monitor A: エラー率 > 5%
+*   Monitor B: リクエスト数 > 50/min
+*   **Composite**: `Monitor A && Monitor B`
+（「エラー率が高い」かつ「トラフィックがある」時だけ通知）
+
+---
+
+## Chapter 7: Security (ASM & Cloud SIEM)
+
+SREの責任範囲はセキュリティにも及びます。
+
+### 7.1 Application Security Management (ASM)
+Datadog ASMを有効化することで、ライブラリの脆弱性検知だけでなく、実行時の攻撃（SQLインジェクション、XSS、SSRFなど）を検知・ブロックできます。
+WAFでは防ぎきれない、アプリケーション内部の挙動ベースの防御です。
+
+### 7.2 Cloud SIEM
+CloudTrailログやVPC Flow LogsをDatadogに取り込み、不審なAWS APIコール（権限昇格の試み、普段使わないリージョンでのインスタンス起動など）を検知します。
+
+---
+
+## Chapter 8: CI/CD Pipeline Visibility
+
+デプロイ頻度が高い環境では、CI/CD自体がボトルネックになります。
+
+### 8.1 Pipeline Monitoring
+GitHub Actions や CodePipeline と連携し、以下のメトリクスを可視化します。
+*   **Build Duration**: ビルドにかかる時間の推移。
+*   **Failure Rate**: テストの失敗率、デプロイの失敗率。
+*   **Flaky Tests**: 「時々失敗するテスト」の特定と駆除。
+
+---
+
+## Chapter 9: Hands-on User Stories (現場で起きる「あの」障害への処方箋)
+
+座学だけでは現場は戦えません。
+ここでは、大規模環境で頻発する**5つの具体的シナリオ**に対して、Datadogを使った「最短の犯人特定フロー」をハンズオン形式で解説します。
+
+### Scenario 1: 「APIが遅い」と言われたが、どこが遅いか分からない
+**状況**: ユーザーから「検索が遅い」とクレームが来た。平均レイテンシは正常だが、p95が悪化している。
+
+**【捜査フロー】**
+1.  **APM > Traces** を開く。
+2.  Filter: `service:search-service`, `env:prod`。
+3.  Sort by: **Duration (desc)**。
+4.  最も遅いトレース（Flame Graph）をクリックし、**Gap Analysis** を行う。
+    *   **Case A**: Lambda開始前に長い空白がある -> **Cold Start**。Provisioned Concurrencyを検討。
+    *   **Case B**: `aws.dynamodb` のSpanが異常に長い -> **DynamoDB Latency**。インデックス不足かデータ量過多。
+    *   **Case C**: Spanの隙間がなく、ただ処理時間が長い -> **CPU Bottleneck**。Profilerを見るか、メモリ割り当てを増やす。
+
+### Scenario 2: 夜間だけ謎のエラーが発生する
+**状況**: 毎晩3:00頃にエラーレートがスパイクするが、朝には直っている。
+
+**【捜査フロー】**
+1.  **Dashboard** で時間帯を絞り込む。
+2.  **Log Overlay** 機能を使い、エラースパイクと同時刻のログを表示。
+3.  **Error Tracking** 画面で、Issueのグルーピングを確認。
+    *   **犯人**: `ConnectionTimeout` が外部バッチ処理（他社システム）と連携するタイミングで多発。
+4.  **Action**: 相手側システムのメンテナンス時間と被っていないか確認し、リトライ戦略（Exponential Backoff）を調整。
+
+### Scenario 3: DynamoDBがスロットリングしているが、全体キャパシティには余裕がある
+**状況**: `ProvisionedThroughputExceededException` が出ているが、テーブル全体の消費RCUは上限の10%以下。
+
+**【捜査フロー】**
+1.  **APM** で該当エラーのトレースを開く。
+2.  Span Tags の `db.statement` (実行されたクエリ) を確認。
+    *   例: `SELECT * FROM Orders WHERE status = 'PENDING'`
+3.  **犯人**: 特定のPartition Key（例: 大口顧客のID）にアクセスが集中する **Hot Partition** 問題。
+4.  **Action**: テーブル設計を見直し、Write Shardingなどを検討。またはOn-Demandモードへの切り替え。
+
+### Scenario 4: N+1問題によるパフォーマンス劣化
+**状況**: 一つのリクエストでDynamoDBへのコール数が異常に多い。
+
+**【捜査フロー】**
+1.  **APM > Traces** でリストを表示。
+2.  Measure: **Span Count** を追加してソート。
+3.  一つのトレース内で `aws.dynamodb` のSpanが100回以上連続している箇所を発見。
+4.  **犯人**: ループ内で `getItem` をしている典型的な **N+1問題**。
+5.  **Action**: `batchGetItem` または `Query` を使い、1回のリクエストでまとめて取得するようにコードを修正。
+
+### Scenario 5: 「処理は成功しているのに、結果が反映されていない」（Silent Failure）
+**状況**: エラーログは出ていないが、ユーザーから「予約が完了していない」と言われる。
+
+**【捜査フロー】**
+1.  **Logs** で `user_id` で検索し、一連のフローを追う。
+2.  Status: `Info` のログも含めて確認。
+3.  **犯人**: `try-catch` ブロックで例外を握りつぶし、`logger.error` を出さずに `return None` しているコードを発見。
+4.  **Action**:
+    *   例外を握りつぶさない。
+    *   Datadogの **Custom Metric** (`app.booking.failure_count`) をインクリメントする処理を追加し、ビジネスロジック上の失敗を可視化する。
+
+---
+
+## まとめ: プロフェッショナルSREのチェックリスト
+
+500関数の大規模環境において、以下の準備ができているか自問してください。
+
+1.  **IaC**: 監視設定はTerraform/CDKで管理されているか？
+2.  **Cost Efficiency**: ログの除外設定とアーカイブ活用で、無駄なコストを削減しているか？
+3.  **Trace**: 非同期処理を含め、Trace ID が途切れず繋がっているか？
+4.  **Database**: DynamoDBのホットキーやクエリ遅延を特定できるか？
+5.  **Profiling**: コードレベルのボトルネック（CPU/メモリ）を特定できるか？
+6.  **Security**: アプリケーションへの攻撃や脆弱性をリアルタイムで検知できるか？
+7.  **SLO**: ユーザー影響に基づいたアラート（Burn Rate）が設定されているか？
+
+これらをクリアした時、あなたはDatadogを「監視ツール」としてではなく、「ビジネスの信頼性を担保するプラットフォーム」として使いこなしていると言えるでしょう。

--- a/events/sfn_input_hotel_fail.json
+++ b/events/sfn_input_hotel_fail.json
@@ -1,0 +1,19 @@
+{
+  "trip_id": "trip-hotel-fail-001",
+  "flight_details": {
+    "flight_number": "NH001",
+    "departure_time": "2026-03-01T10:00:00",
+    "arrival_time": "2026-03-01T14:00:00",
+    "price_amount": 50000,
+    "price_currency": "JPY"
+  },
+  "hotel_details": {
+    "hotel_name": "",
+    "check_in_date": "invalid-date",
+    "check_out_date": "2026-03-03",
+    "price_amount": 30000,
+    "price_currency": "JPY"
+  },
+  "amount": 80000,
+  "currency": "JPY"
+}

--- a/events/sfn_input_payment_fail.json
+++ b/events/sfn_input_payment_fail.json
@@ -1,0 +1,19 @@
+{
+  "trip_id": "trip-payment-fail-001",
+  "flight_details": {
+    "flight_number": "NH001",
+    "departure_time": "2026-03-01T10:00:00",
+    "arrival_time": "2026-03-01T14:00:00",
+    "price_amount": 50000,
+    "price_currency": "JPY"
+  },
+  "hotel_details": {
+    "hotel_name": "Grand Hotel Tokyo",
+    "check_in_date": "2026-03-01",
+    "check_out_date": "2026-03-03",
+    "price_amount": 30000,
+    "price_currency": "JPY"
+  },
+  "amount": -1,
+  "currency": "JPY"
+}

--- a/events/sfn_input_success.json
+++ b/events/sfn_input_success.json
@@ -1,0 +1,19 @@
+{
+  "trip_id": "trip-success-001",
+  "flight_details": {
+    "flight_number": "NH001",
+    "departure_time": "2026-03-01T10:00:00",
+    "arrival_time": "2026-03-01T14:00:00",
+    "price_amount": 50000,
+    "price_currency": "JPY"
+  },
+  "hotel_details": {
+    "hotel_name": "Grand Hotel Tokyo",
+    "check_in_date": "2026-03-01",
+    "check_out_date": "2026-03-03",
+    "price_amount": 30000,
+    "price_currency": "JPY"
+  },
+  "amount": 80000,
+  "currency": "JPY"
+}


### PR DESCRIPTION
- 大規模環境向けDatadog運用ガイド (Hands-on 13) を作成
- E2E検証とカオステストの手順書 (Hands-on 12) を作成
- 検証用のJSONペイロードを追加