### PR TITLE
Step Functions のトレース, メトリクスを有効化

### DIFF
--- a/infra/constructs/observability.py
+++ b/infra/constructs/observability.py
@@ -53,6 +53,7 @@ class Observability(Construct):
                 "DdTraceEnabled": "true",
                 "DdFetchLambdaTags": "true",
                 "DdFetchStepFunctionsTags": "true",
+                "DdStepFunctionsTraceEnabled": "true",
             },
         )
 


### PR DESCRIPTION
原因は Datadog Forwarder の設定不足
先ほどのスタック確認結果 (aws cloudformation describe-stacks) において、以下のパラメータが false になっていました。

   1 {
   2     "ParameterKey": "DdStepFunctionsTraceEnabled",
   3     "ParameterValue": "false"
   4 }

  このパラメータ (DdStepFunctionsTraceEnabled) が false のままだと、Step Functions のログは単なる「ログ」として扱われ、Datadog Serverless View
  に必要なトレース情報やメトリクスとして処理されません。その結果、Step Functions の一覧に表示されません。