### PR TITLE
fix: enable TCP Keep-Alive for all DynamoDB boto3 clients

### DIFF
--- a/src/services/flight/infrastructure/dynamodb_booking_repository.py
+++ b/src/services/flight/infrastructure/dynamodb_booking_repository.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 import boto3
 from boto3.dynamodb.conditions import Attr, Key
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from services.flight.domain.entity.booking import Booking
@@ -21,7 +22,7 @@ class DynamoDBBookingRepository(BookingRepository):
 
     def __init__(self, table_name: str | None = None) -> None:
         self.table_name = table_name or os.getenv("TABLE_NAME")
-        self.dynamodb = boto3.resource("dynamodb")
+        self.dynamodb = boto3.resource("dynamodb", config=Config(tcp_keepalive=True))
         self.table = self.dynamodb.Table(self.table_name)
 
     def save(self, booking: Booking) -> None:

--- a/src/services/hotel/infrastructure/dynamodb_hotel_booking_repository.py
+++ b/src/services/hotel/infrastructure/dynamodb_hotel_booking_repository.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 import boto3
 from boto3.dynamodb.conditions import Attr, Key
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from services.hotel.domain.entity import HotelBooking
@@ -21,7 +22,7 @@ class DynamoDBHotelBookingRepository(HotelBookingRepository):
 
     def __init__(self, table_name: str | None = None) -> None:
         self.table_name = table_name or os.getenv("TABLE_NAME")
-        self.dynamodb = boto3.resource("dynamodb")
+        self.dynamodb = boto3.resource("dynamodb", config=Config(tcp_keepalive=True))
         self.table = self.dynamodb.Table(self.table_name)
 
     def save(self, booking: HotelBooking) -> None:

--- a/src/services/payment/infrastructure/dynamodb_payment_repository.py
+++ b/src/services/payment/infrastructure/dynamodb_payment_repository.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 import boto3
 from boto3.dynamodb.conditions import Attr, Key
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from services.payment.domain.entity import Payment
@@ -29,7 +30,7 @@ class DynamoDBPaymentRepository(PaymentRepository):
 
     def __init__(self, table_name: str | None = None) -> None:
         self.table_name = table_name or os.getenv("TABLE_NAME")
-        self.dynamodb = boto3.resource("dynamodb")
+        self.dynamodb = boto3.resource("dynamodb", config=Config(tcp_keepalive=True))
         self.table = self.dynamodb.Table(self.table_name)
 
     def save(self, payment: Payment) -> None:

--- a/src/services/trip/handlers/get_trip.py
+++ b/src/services/trip/handlers/get_trip.py
@@ -9,13 +9,14 @@ from aws_lambda_powertools.utilities.data_classes import (
 )
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.dynamodb.conditions import Key
+from botocore.config import Config
 
 from services.shared.utils import api_response
 
 logger = Logger()
 
 TABLE_NAME = os.environ["TABLE_NAME"]
-dynamodb = boto3.resource("dynamodb")
+dynamodb = boto3.resource("dynamodb", config=Config(tcp_keepalive=True))
 table = dynamodb.Table(TABLE_NAME)
 
 

--- a/src/services/trip/handlers/list_trips.py
+++ b/src/services/trip/handlers/list_trips.py
@@ -8,13 +8,14 @@ from aws_lambda_powertools.utilities.data_classes import (
 )
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.dynamodb.conditions import Key
+from botocore.config import Config
 
 from services.shared.utils import api_response
 
 logger = Logger()
 
 TABLE_NAME = os.environ["TABLE_NAME"]
-dynamodb = boto3.resource("dynamodb")
+dynamodb = boto3.resource("dynamodb", config=Config(tcp_keepalive=True))
 table = dynamodb.Table(TABLE_NAME)
 
 NUM_SHARDS = 4

--- a/src/services/trip/handlers/search_trips.py
+++ b/src/services/trip/handlers/search_trips.py
@@ -4,8 +4,9 @@ from typing import Any
 
 import boto3
 from boto3.dynamodb.conditions import Key
+from botocore.config import Config
 
-dynamodb = boto3.resource("dynamodb")
+dynamodb = boto3.resource("dynamodb", config=Config(tcp_keepalive=True))
 search_table = dynamodb.Table(os.environ["SEARCH_TABLE_NAME"])
 
 INDEX_NAME = "flight_status-departure_time-index"

--- a/src/services/trip/handlers/stream_consumer.py
+++ b/src/services/trip/handlers/stream_consumer.py
@@ -5,11 +5,12 @@ from decimal import Decimal
 import boto3
 from boto3.dynamodb.conditions import Attr
 from boto3.dynamodb.types import TypeDeserializer
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 deserializer = TypeDeserializer()
 
-dynamodb = boto3.resource("dynamodb")
+dynamodb = boto3.resource("dynamodb", config=Config(tcp_keepalive=True))
 search_table = dynamodb.Table(os.environ["SEARCH_TABLE_NAME"])
 
 


### PR DESCRIPTION
Add botocore.config.Config(tcp_keepalive=True) to all boto3.resource("dynamodb") calls across flight/hotel/payment repositories and trip handlers to maintain persistent TCP connections during Lambda warm starts.